### PR TITLE
Enhancement/UI tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AION Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=JetBrains+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet" />
   </head>
   <body>
 <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,75 +10,43 @@ import Settings from './pages/Settings';
 import NotFound from './pages/NotFound';
 import { AccessibilityProvider } from './contexts/AccessibilityContext';
 
+const PAGE_META = {
+  '/':            { title: 'Ingestion',    subtitle: 'Real-time network data streaming' },
+  '/ml':          { title: 'ML Models',    subtitle: 'Browse and manage model instances' },
+  '/analytics':   { title: 'Analytics',    subtitle: 'Cell analytics and predictions' },
+  '/performance': { title: 'Performance',  subtitle: 'Real-time ML model monitoring' },
+  '/policy':      { title: 'Policy',       subtitle: 'Data transformation and field permissions' },
+  '/settings':    { title: 'Settings',     subtitle: 'Accessibility and display preferences' },
+};
+
 function AppContent() {
   const location = useLocation();
-
-  // Get page title based on current route
-  const getPageTitle = () => {
-    switch (location.pathname) {
-      case '/':
-        return 'Ingestion';
-      case '/ml':
-        return 'ML';
-      case '/analytics':
-        return 'Analytics';
-      case '/performance':
-        return 'Performance';
-      case '/policy':
-        return 'Policy';
-      case '/settings':
-        return 'Settings';
-      default:
-        return 'AION';
-    }
-  };
-
-  const getPageSubtitle = () => {
-    switch (location.pathname) {
-      case '/':
-        return 'Real-time Network Monitoring';
-      case '/ml':
-        return 'Browse and Manage model instances';
-      case '/analytics':
-        return 'Cell Analytics Insights';
-      case '/performance':
-        return 'Real-time ML Model Performance Monitoring';
-      case '/policy':
-        return 'Data transformation and field permissions';
-      case '/settings':
-        return 'Accessibility & Display Preferences';
-      default:
-        return '';
-    }
-  };
+  const meta = PAGE_META[location.pathname] ?? { title: 'AION', subtitle: '' };
 
   return (
-    <div className="flex h-screen bg-gray-100">
-      {/* Sidebar */}
+    <div className="flex h-screen overflow-hidden" style={{ background: 'var(--bg)' }}>
       <Sidebar />
 
-      {/* Main Content */}
-      <div className="flex-1 overflow-auto">
-        {/* Header */}
-        <header className="bg-gradient-to-r from-blue-500 to-blue-600 px-4 sm:px-8 py-4 sm:py-6 shadow-md">
-          <h1 className="text-3xl font-bold text-white">{getPageTitle()}</h1>
-          <p className="text-blue-50 mt-1">
-            {getPageSubtitle()}
-          </p>
+      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
+        <header className="page-header shrink-0">
+          <div className="page-header-accent" aria-hidden="true" />
+          <div>
+            <h1>{meta.title}</h1>
+            {meta.subtitle && <p>{meta.subtitle}</p>}
+          </div>
         </header>
 
-        {/* Page Content */}
-        <div className="p-4 sm:p-8">
+        <main className="flex-1 overflow-auto p-4 sm:p-6 lg:p-8">
           <Routes>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/ml" element={<MLModels />} />
-            <Route path="/analytics" element={<Analytics />} />
+            <Route path="/"            element={<Dashboard />} />
+            <Route path="/ml"          element={<MLModels />} />
+            <Route path="/analytics"   element={<Analytics />} />
             <Route path="/performance" element={<Performance />} />
-            <Route path="/policy" element={<Policy />} />
-            <Route path="/settings" element={<Settings />} />
-            <Route path="*" element={<NotFound />} />
+            <Route path="/policy"      element={<Policy />} />
+            <Route path="/settings"    element={<Settings />} />
+            <Route path="*"            element={<NotFound />} />
           </Routes>
-        </div>
+        </main>
       </div>
     </div>
   );
@@ -88,7 +56,7 @@ function App() {
   return (
     <Router>
       <AccessibilityProvider>
-          <AppContent />
+        <AppContent />
       </AccessibilityProvider>
     </Router>
   );

--- a/src/components/ProducerManager.jsx
+++ b/src/components/ProducerManager.jsx
@@ -1,91 +1,78 @@
 import React, { useState, useEffect } from 'react';
-import { FaEdit, FaTimes, FaCheck } from 'react-icons/fa';
 import { createPortal } from 'react-dom';
 
+const EVENTS = ['PERF_DATA', 'UE_MOBILITY', 'UE_COMM'];
+
 const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
-  const [producers, setProducers] = useState([]);
+  const [subscriptions, setSubscriptions] = useState([]);
   const [showModal, setShowModal] = useState(false);
-  const [url, setUrl] = useState('');
-  const [label, setLabel] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [editingLabel, setEditingLabel] = useState(null);
-  const [labelValue, setLabelValue] = useState('');
-  const [savingLabel, setSavingLabel] = useState(false);
 
-  const fetchProducers = async () => {
+  const [form, setForm] = useState({
+    notifId: '',
+    nefUrl: '',
+    events: [],
+    snssai_sst: '',
+    snssai_sd: '',
+    dnn: '',
+  });
+
+  const fetchSubscriptions = async () => {
     try {
-      const res = await fetch(`${apiBase}/subscriptions`);
-      if (!res.ok) throw new Error(`Failed to fetch producers: ${res.status}`);
+      const res = await fetch(`${apiBase}/nef/subscriptions`);
+      if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`);
       const data = await res.json();
-      // Handle both old and new formats
-      let producersList = [];
-
-      if (data.producers && Array.isArray(data.producers)) {
-        producersList = data.producers;
-      } else if (data.active && Array.isArray(data.active)) {
-        producersList = [...data.active, ...data.inactive];
-      } else {
-        producersList = [];
-      }
-
-      const parsed = producersList
-        .map((item) => {
-          const entries = Object.entries(item || {});
-          if (entries.length === 0) return null;
-          const [id, info] = entries[0];
-          if (typeof info === 'string') {
-            return { id, url: info, label: id };
-          }
-          return { id, url: info.url || '', label: info.label || id };
-        })
-        .filter(Boolean);
-      setProducers(parsed);
+      setSubscriptions(Array.isArray(data.subscriptions) ? data.subscriptions : []);
     } catch (err) {
       console.error(err);
     }
   };
 
   useEffect(() => {
-    fetchProducers();
-    const id = setInterval(fetchProducers, 5000);
+    fetchSubscriptions();
+    const id = setInterval(fetchSubscriptions, 5000);
     return () => clearInterval(id);
   }, [apiBase]);
 
-  const addProducer = async (e) => {
+  const resetForm = () => setForm({ notifId: '', nefUrl: '', events: [], snssai_sst: '', snssai_sd: '', dnn: '' });
+
+  const toggleEvent = (evt) => {
+    setForm(prev => ({
+      ...prev,
+      events: prev.events.includes(evt) ? prev.events.filter(e => e !== evt) : [...prev.events, evt],
+    }));
+  };
+
+  const addSubscription = async (e) => {
     e.preventDefault();
-    if (!url.trim()) return;
+    if (!form.notifId.trim() || !form.nefUrl.trim() || form.events.length === 0) return;
     setLoading(true);
     setError(null);
     try {
-      // First, create the subscription
-      const res = await fetch(`${apiBase}/subscriptions`, {
+      const body = {
+        notifId: form.notifId.trim(),
+        nefUrl: form.nefUrl.trim(),
+        events: form.events,
+      };
+      if (form.snssai_sst.trim()) {
+        body.snssai = { sst: form.snssai_sst.trim() };
+        if (form.snssai_sd.trim()) body.snssai.sd = form.snssai_sd.trim();
+      }
+      if (form.dnn.trim()) body.dnn = form.dnn.trim();
+
+      const res = await fetch(`${apiBase}/nef/subscriptions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          producer_url: url.trim(),
-        }),
+        body: JSON.stringify(body),
       });
-      if (!res.ok) throw new Error(`Failed to add producer: ${res.status}`);
-
-      // If a label was provided, update it using the label endpoint
-      const labelToSet = label.trim();
-      if (labelToSet) {
-        const data = await res.json();
-        const subscriptionId = data.subscription_id || data.id;
-        if (subscriptionId) {
-          await fetch(`${apiBase}/subscriptions/${subscriptionId}/label`, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ label: labelToSet })
-          });
-        }
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({}));
+        throw new Error(errData.detail || `Failed to add: ${res.status}`);
       }
-
-      setUrl('');
-      setLabel('');
+      resetForm();
       setShowModal(false);
-      await fetchProducers();
+      await fetchSubscriptions();
     } catch (err) {
       setError(err.message);
     } finally {
@@ -93,97 +80,123 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
     }
   };
 
-  const removeProducer = async (id) => {
-    if (!confirm('Remove this producer?')) return;
+  const removeSubscription = async (notifId) => {
+    if (!confirm(`Remove subscription "${notifId}"?`)) return;
     try {
-      const res = await fetch(`${apiBase}/subscriptions/${id}`, { method: 'DELETE' });
-      if (!res.ok) throw new Error(`Failed to delete: ${res.status}`);
-      await fetchProducers();
-      if (onRemove) onRemove(id);
+      const res = await fetch(`${apiBase}/nef/subscriptions/${encodeURIComponent(notifId)}`, { method: 'DELETE' });
+      if (!res.ok && res.status !== 204) throw new Error(`Failed to delete: ${res.status}`);
+      await fetchSubscriptions();
+      if (onRemove) onRemove(notifId);
     } catch (err) {
       console.error(err);
-    }
-  };
-
-  const startEditLabel = (producer) => {
-    setEditingLabel(producer.id);
-    setLabelValue(producer.label);
-  };
-
-  const cancelEditLabel = () => {
-    setEditingLabel(null);
-    setLabelValue('');
-  };
-
-  const saveLabel = async (subscriptionId) => {
-    if (!labelValue.trim()) {
-      setError('Label cannot be empty');
-      return;
-    }
-    setSavingLabel(true);
-    setError(null);
-    try {
-      const res = await fetch(`${apiBase}/subscriptions/${subscriptionId}/label`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ label: labelValue.trim() })
-      });
-      if (!res.ok) throw new Error(`Failed to update label: ${res.status}`);
-      await fetchProducers();
-      setEditingLabel(null);
-      setLabelValue('');
-    } catch (err) {
-      console.error(err);
-      setError(err.message);
-    } finally {
-      setSavingLabel(false);
     }
   };
 
   return (
     <>
-      {/* Add Producer Modal - rendered via portal to avoid stacking context issues */}
       {showModal && createPortal(
         <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6 space-y-4">
+          <div className="bg-white rounded-lg shadow-xl max-w-lg w-full p-6 space-y-4">
             <div className="flex items-center justify-between">
-              <h3 className="text-lg font-bold text-gray-900">Add Producer</h3>
-              <button
-                onClick={() => { setShowModal(false); setUrl(''); setLabel(''); setError(null); }}
-                className="text-gray-400 hover:text-gray-600 transition-colors"
-              >
+              <h3 className="text-lg font-bold text-gray-900">Add NEF Subscription</h3>
+              <button onClick={() => { setShowModal(false); resetForm(); setError(null); }} className="text-gray-400 hover:text-gray-600">
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>
             </div>
 
-            <form onSubmit={addProducer} className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  URL <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="text"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm"
-                  placeholder="e.g. http://host:port"
-                  value={url}
-                  onChange={(e) => setUrl(e.target.value)}
-                  required
-                />
-              </div>
+            <form onSubmit={addSubscription} className="space-y-4">
+              <div className="grid grid-cols-1 gap-3">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Notification ID <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                    placeholder="e.g. my-nef-sub-1"
+                    value={form.notifId}
+                    onChange={e => setForm(p => ({ ...p, notifId: e.target.value }))}
+                    required
+                  />
+                </div>
 
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Label <span className="text-gray-400">(optional)</span>
-                </label>
-                <input
-                  type="text"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm"
-                  placeholder="e.g. Producer 1"
-                  value={label}
-                  onChange={(e) => setLabel(e.target.value)}
-                />
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    NEF URL <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                    placeholder="e.g. http://nef-host:8080/nef/subscribe"
+                    value={form.nefUrl}
+                    onChange={e => setForm(p => ({ ...p, nefUrl: e.target.value }))}
+                    required
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Events <span className="text-red-500">*</span>
+                  </label>
+                  <div className="flex gap-2">
+                    {EVENTS.map(evt => (
+                      <button
+                        key={evt}
+                        type="button"
+                        onClick={() => toggleEvent(evt)}
+                        className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
+                          form.events.includes(evt)
+                            ? 'bg-blue-600 border-blue-600 text-white'
+                            : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-50'
+                        }`}
+                      >
+                        {evt}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      S-NSSAI SST <span className="text-gray-400 font-normal">(optional)</span>
+                    </label>
+                    <input
+                      type="text"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                      placeholder="e.g. 1"
+                      value={form.snssai_sst}
+                      onChange={e => setForm(p => ({ ...p, snssai_sst: e.target.value }))}
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      S-NSSAI SD <span className="text-gray-400 font-normal">(optional)</span>
+                    </label>
+                    <input
+                      type="text"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                      placeholder="e.g. 000001"
+                      value={form.snssai_sd}
+                      onChange={e => setForm(p => ({ ...p, snssai_sd: e.target.value }))}
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    DNN <span className="text-gray-400 font-normal">(optional)</span>
+                  </label>
+                  <input
+                    type="text"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                    placeholder="e.g. internet"
+                    value={form.dnn}
+                    onChange={e => setForm(p => ({ ...p, dnn: e.target.value }))}
+                  />
+                </div>
               </div>
 
               {error && <p className="text-sm text-red-600">{error}</p>}
@@ -191,20 +204,20 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
               <div className="flex gap-3 pt-2">
                 <button
                   type="button"
-                  onClick={() => { setShowModal(false); setUrl(''); setLabel(''); setError(null); }}
-                  className="flex-1 px-4 py-2 border border-gray-300 text-gray-700 font-medium rounded-lg hover:bg-gray-50 transition-colors text-sm"
+                  onClick={() => { setShowModal(false); resetForm(); setError(null); }}
+                  className="flex-1 px-4 py-2 border border-gray-300 text-gray-700 font-medium rounded-lg hover:bg-gray-50 text-sm"
                   disabled={loading}
                 >
                   Cancel
                 </button>
                 <button
                   type="submit"
-                  disabled={loading || !url.trim()}
-                  className="flex-1 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-sm flex items-center justify-center gap-2"
+                  disabled={loading || !form.notifId.trim() || !form.nefUrl.trim() || form.events.length === 0}
+                  className="flex-1 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg disabled:opacity-50 disabled:cursor-not-allowed text-sm flex items-center justify-center gap-2"
                 >
                   {loading ? (
                     <><div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>Adding...</>
-                  ) : 'Add Producer'}
+                  ) : 'Add Subscription'}
                 </button>
               </div>
             </form>
@@ -215,17 +228,17 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
       <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
         <div className="flex items-center justify-between mb-4">
           <div>
-            <h2 className="text-lg font-bold text-gray-900">Producers</h2>
-            <p className="text-sm text-gray-600 mt-1">Manage data ingestion producers and their labels</p>
+            <h2 className="text-lg font-bold text-gray-900">NEF Subscriptions</h2>
+            <p className="text-sm text-gray-600 mt-1">Manage active NEF event subscriptions</p>
           </div>
           <button
             onClick={() => setShowModal(true)}
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors flex items-center gap-2"
+            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg flex items-center gap-2"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
             </svg>
-            Add Producer
+            Add Subscription
           </button>
         </div>
 
@@ -233,75 +246,50 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Label</th>
-                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Subscription ID</th>
-                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">URL</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Notif ID</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">NEF URL</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Events</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Tags</th>
                 <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
-              {producers.length === 0 ? (
+              {subscriptions.length === 0 ? (
                 <tr>
-                  <td colSpan={4} className="px-4 py-6 text-center text-sm text-gray-500">No producers configured</td>
+                  <td colSpan={5} className="px-4 py-6 text-center text-sm text-gray-500">No subscriptions configured</td>
                 </tr>
               ) : (
-                producers.map((p) => (
-                  <tr key={p.id} className="hover:bg-gray-50">
-                    <td className="px-4 py-3 text-sm">
-                      {editingLabel === p.id ? (
-                        <div className="flex items-center gap-2">
-                          <input
-                            type="text"
-                            className="px-2 py-1 border rounded-md text-sm w-32"
-                            value={labelValue}
-                            onChange={(e) => setLabelValue(e.target.value)}
-                            autoFocus
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter') saveLabel(p.id);
-                              if (e.key === 'Escape') cancelEditLabel();
-                            }}
-                          />
-                          <button
-                            className="p-1 rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
-                            onClick={() => saveLabel(p.id)}
-                            disabled={savingLabel}
-                          >
-                            <FaCheck size={12} />
-                          </button>
-                          <button
-                            className="p-1 rounded-md bg-gray-600 text-white hover:bg-gray-700"
-                            onClick={cancelEditLabel}
-                          >
-                            <FaTimes size={12} />
-                          </button>
+                subscriptions.map((sub) => {
+                  const sst = sub.snssai?.sst ?? sub.snssai?.snssaiSst;
+                  const sd = sub.snssai?.sd ?? sub.snssai?.snssaiSd;
+                  const snssaiStr = sst ? `sst=${sst}${sd ? ` sd=${sd}` : ''}` : null;
+                  return (
+                    <tr key={sub.notif_id} className="hover:bg-gray-50">
+                      <td className="px-4 py-3 text-sm font-mono text-gray-900">{sub.notif_id}</td>
+                      <td className="px-4 py-3 text-sm text-gray-700 break-all max-w-xs">{sub.nef_url}</td>
+                      <td className="px-4 py-3 text-sm">
+                        <div className="flex flex-wrap gap-1">
+                          {(sub.events || []).map(e => (
+                            <span key={e} className="px-2 py-0.5 rounded bg-blue-100 text-blue-800 text-xs font-medium">{e}</span>
+                          ))}
                         </div>
-                      ) : (
-                        <div className="flex items-center gap-2">
-                          <span className="inline-flex items-center px-2 py-1 rounded-md bg-blue-100 text-blue-800 text-xs font-medium">
-                            {p.label}
-                          </span>
-                          <button
-                            className="text-gray-400 hover:text-gray-600"
-                            onClick={() => startEditLabel(p)}
-                            title="Edit label"
-                          >
-                            <FaEdit size={14} />
-                          </button>
-                        </div>
-                      )}
-                    </td>
-                    <td className="px-4 py-3 text-sm text-gray-900 font-mono break-all">{p.id}</td>
-                    <td className="px-4 py-3 text-sm text-gray-700 break-all">{p.url}</td>
-                    <td className="px-4 py-3 text-sm">
-                      <button
-                        className="px-3 py-1 rounded-md bg-red-600 text-white hover:bg-red-700 text-sm"
-                        onClick={() => removeProducer(p.id)}
-                      >
-                        Remove
-                      </button>
-                    </td>
-                  </tr>
-                ))
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600">
+                        {snssaiStr && <div className="text-xs font-mono">{snssaiStr}</div>}
+                        {sub.dnn && <div className="text-xs text-gray-500">dnn={sub.dnn}</div>}
+                        {!snssaiStr && !sub.dnn && <span className="text-gray-400">—</span>}
+                      </td>
+                      <td className="px-4 py-3 text-sm">
+                        <button
+                          className="px-3 py-1 rounded-md bg-red-600 text-white hover:bg-red-700 text-sm"
+                          onClick={() => removeSubscription(sub.notif_id)}
+                        >
+                          Remove
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })
               )}
             </tbody>
           </table>

--- a/src/components/ProducerManager.jsx
+++ b/src/components/ProducerManager.jsx
@@ -3,11 +3,25 @@ import { createPortal } from 'react-dom';
 
 const EVENTS = ['PERF_DATA', 'UE_MOBILITY', 'UE_COMM'];
 
+const CopyBtn = ({ text, id, copiedId, onCopy }) => (
+  <button
+    onClick={() => onCopy(text, id)}
+    className="p-1 rounded hover:bg-gray-100 transition-colors shrink-0"
+    title="Copy"
+  >
+    {copiedId === id
+      ? <svg className="w-3.5 h-3.5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+      : <svg className="w-3.5 h-3.5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+    }
+  </button>
+);
+
 const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
   const [subscriptions, setSubscriptions] = useState([]);
   const [showModal, setShowModal] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [copiedId, setCopiedId] = useState(null);
 
   const [form, setForm] = useState({
     notifId: '',
@@ -17,6 +31,21 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
     snssai_sd: '',
     dnn: '',
   });
+
+  const copyToClipboard = (text, id) => {
+    const fallback = () => {
+      const el = document.createElement('textarea');
+      el.value = text;
+      el.style.cssText = 'position:fixed;opacity:0';
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand('copy');
+      document.body.removeChild(el);
+    };
+    navigator.clipboard?.writeText(text).catch(fallback) ?? fallback();
+    setCopiedId(id);
+    setTimeout(() => setCopiedId(null), 2000);
+  };
 
   const fetchSubscriptions = async () => {
     try {
@@ -95,11 +124,11 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
   return (
     <>
       {showModal && createPortal(
-        <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg shadow-xl max-w-lg w-full p-6 space-y-4">
+        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-xl shadow-xl max-w-lg w-full p-6 space-y-4">
             <div className="flex items-center justify-between">
-              <h3 className="text-lg font-bold text-gray-900">Add NEF Subscription</h3>
-              <button onClick={() => { setShowModal(false); resetForm(); setError(null); }} className="text-gray-400 hover:text-gray-600">
+              <h3 className="text-base font-semibold text-gray-900">Add NEF Subscription</h3>
+              <button onClick={() => { setShowModal(false); resetForm(); setError(null); }} className="text-gray-400 hover:text-gray-600 transition-colors">
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                 </svg>
@@ -114,7 +143,7 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
                   </label>
                   <input
                     type="text"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
                     placeholder="e.g. my-nef-sub-1"
                     value={form.notifId}
                     onChange={e => setForm(p => ({ ...p, notifId: e.target.value }))}
@@ -128,7 +157,7 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
                   </label>
                   <input
                     type="text"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
                     placeholder="e.g. http://nef-host:8080/nef/subscribe"
                     value={form.nefUrl}
                     onChange={e => setForm(p => ({ ...p, nefUrl: e.target.value }))}
@@ -165,7 +194,7 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
                     </label>
                     <input
                       type="text"
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
                       placeholder="e.g. 1"
                       value={form.snssai_sst}
                       onChange={e => setForm(p => ({ ...p, snssai_sst: e.target.value }))}
@@ -177,7 +206,7 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
                     </label>
                     <input
                       type="text"
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
                       placeholder="e.g. 000001"
                       value={form.snssai_sd}
                       onChange={e => setForm(p => ({ ...p, snssai_sd: e.target.value }))}
@@ -191,7 +220,7 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
                   </label>
                   <input
                     type="text"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
                     placeholder="e.g. internet"
                     value={form.dnn}
                     onChange={e => setForm(p => ({ ...p, dnn: e.target.value }))}
@@ -215,9 +244,10 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
                   disabled={loading || !form.notifId.trim() || !form.nefUrl.trim() || form.events.length === 0}
                   className="flex-1 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg disabled:opacity-50 disabled:cursor-not-allowed text-sm flex items-center justify-center gap-2"
                 >
-                  {loading ? (
-                    <><div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>Adding...</>
-                  ) : 'Add Subscription'}
+                  {loading
+                    ? <><div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />Adding…</>
+                    : 'Add Subscription'
+                  }
                 </button>
               </div>
             </form>
@@ -225,20 +255,20 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
         </div>
       , document.body)}
 
-      <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+      <div className="bg-white rounded-xl border border-gray-200 p-5 shadow-sm">
         <div className="flex items-center justify-between mb-4">
           <div>
-            <h2 className="text-lg font-bold text-gray-900">NEF Subscriptions</h2>
-            <p className="text-sm text-gray-600 mt-1">Manage active NEF event subscriptions</p>
+            <h2 className="text-base font-semibold text-gray-900">NEF Subscriptions</h2>
+            <p className="text-xs text-gray-500 mt-0.5">Active NEF event subscriptions</p>
           </div>
           <button
             onClick={() => setShowModal(true)}
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg flex items-center gap-2"
+            className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg flex items-center gap-1.5 transition-colors"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
             </svg>
-            Add Subscription
+            Add
           </button>
         </div>
 
@@ -246,17 +276,17 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Notif ID</th>
-                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">NEF URL</th>
-                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Events</th>
-                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Tags</th>
-                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Notif ID</th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">NEF URL</th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Events</th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Tags</th>
+                <th className="px-4 py-2.5 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Actions</th>
               </tr>
             </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
+            <tbody className="bg-white divide-y divide-gray-100">
               {subscriptions.length === 0 ? (
                 <tr>
-                  <td colSpan={5} className="px-4 py-6 text-center text-sm text-gray-500">No subscriptions configured</td>
+                  <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-400">No subscriptions configured</td>
                 </tr>
               ) : (
                 subscriptions.map((sub) => {
@@ -265,23 +295,35 @@ const ProducerManager = ({ apiBase = '/data-ingestion', onRemove }) => {
                   const snssaiStr = sst ? `sst=${sst}${sd ? ` sd=${sd}` : ''}` : null;
                   return (
                     <tr key={sub.notif_id} className="hover:bg-gray-50">
-                      <td className="px-4 py-3 text-sm font-mono text-gray-900">{sub.notif_id}</td>
-                      <td className="px-4 py-3 text-sm text-gray-700 break-all max-w-xs">{sub.nef_url}</td>
-                      <td className="px-4 py-3 text-sm">
+                      <td className="px-4 py-2.5">
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-sm font-mono text-gray-900">{sub.notif_id}</span>
+                          <CopyBtn text={sub.notif_id} id={`nid-${sub.notif_id}`} copiedId={copiedId} onCopy={copyToClipboard} />
+                        </div>
+                      </td>
+                      <td className="px-4 py-2.5 max-w-xs">
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-xs text-gray-600 font-mono break-all line-clamp-2" title={sub.nef_url}>
+                            {sub.nef_url}
+                          </span>
+                          <CopyBtn text={sub.nef_url} id={`url-${sub.notif_id}`} copiedId={copiedId} onCopy={copyToClipboard} />
+                        </div>
+                      </td>
+                      <td className="px-4 py-2.5">
                         <div className="flex flex-wrap gap-1">
                           {(sub.events || []).map(e => (
-                            <span key={e} className="px-2 py-0.5 rounded bg-blue-100 text-blue-800 text-xs font-medium">{e}</span>
+                            <span key={e} className="px-1.5 py-0.5 rounded bg-gray-100 text-gray-600 text-xs font-medium">{e}</span>
                           ))}
                         </div>
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-600">
-                        {snssaiStr && <div className="text-xs font-mono">{snssaiStr}</div>}
-                        {sub.dnn && <div className="text-xs text-gray-500">dnn={sub.dnn}</div>}
-                        {!snssaiStr && !sub.dnn && <span className="text-gray-400">—</span>}
+                      <td className="px-4 py-2.5 text-xs text-gray-600 font-mono">
+                        {snssaiStr && <div>{snssaiStr}</div>}
+                        {sub.dnn && <div className="text-gray-500">dnn={sub.dnn}</div>}
+                        {!snssaiStr && !sub.dnn && <span className="text-gray-300">—</span>}
                       </td>
-                      <td className="px-4 py-3 text-sm">
+                      <td className="px-4 py-2.5">
                         <button
-                          className="px-3 py-1 rounded-md bg-red-600 text-white hover:bg-red-700 text-sm"
+                          className="px-2.5 py-1 rounded-md border border-red-200 text-red-600 hover:bg-red-50 text-xs font-medium transition-colors"
                           onClick={() => removeSubscription(sub.notif_id)}
                         >
                           Remove

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,98 +1,134 @@
 import React, { useState, useEffect } from 'react';
 import { NavLink } from 'react-router-dom';
-import { FaHouse } from 'react-icons/fa6';
-import { FaRobot, FaShieldAlt } from 'react-icons/fa';
-import { FaPlug } from 'react-icons/fa6';
+import { FaPlug, FaRobot, FaShieldAlt, FaBars, FaChevronLeft, FaChartLine, FaCog, FaExternalLinkAlt } from 'react-icons/fa';
 import { VscGraph } from 'react-icons/vsc';
-import { FaBars, FaChevronLeft, FaChartLine, FaCog } from 'react-icons/fa';
+
+const NAV_ITEMS = [
+  { name: 'Ingestion',   icon: FaPlug,      path: '/' },
+  { name: 'ML Models',   icon: FaRobot,     path: '/ml' },
+  { name: 'Analytics',   icon: VscGraph,    path: '/analytics' },
+  { name: 'Performance', icon: FaChartLine, path: '/performance' },
+  { name: 'Policy',      icon: FaShieldAlt, path: '/policy' },
+];
+
+const mlflowUrl = import.meta.env.VITE_MLFLOW_URL || 'http://localhost:5000';
 
 const Sidebar = () => {
-  const [isCollapsed, setIsCollapsed] = useState(window.innerWidth < 1024);
+  const [collapsed, setCollapsed] = useState(window.innerWidth < 1024);
 
-  const navItems = [
-    { name: 'Ingestion', icon: <FaPlug />, path: '/' },
-    { name: 'ML', icon: <FaRobot />, path: '/ml' },
-    { name: 'Analytics', icon: <VscGraph />, path: '/analytics' },
-    { name: 'Performance', icon: <FaChartLine />, path: '/performance' },
-    { name: 'Policy', icon: <FaShieldAlt />, path: '/policy' },
-  ];
-
-  // Auto-collapse on small screens
   useEffect(() => {
-    const handleResize = () => {
-      setIsCollapsed(window.innerWidth < 1024);
-    };
-
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    const onResize = () => setCollapsed(window.innerWidth < 1024);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
   }, []);
 
-  const handleToggle = () => {
-    setIsCollapsed(!isCollapsed);
-  };
-
   return (
-    <div className={`${isCollapsed ? 'w-20' : 'w-64'} h-screen bg-white border-r border-gray-200 flex flex-col shadow-sm transition-all duration-300`}>
-      {/* Logo/Header */}
-      <div className="p-6 border-b border-gray-200">
-        <div className="flex items-center justify-between">
-          <div className={`flex items-center space-x-3 ${isCollapsed ? 'hidden' : ''}`}>
-            <img src="/logo.svg" alt="AION Logo" className="w-8 h-8" />
-            <h1 className="text-2xl font-bold bg-gradient-to-r from-blue-500 to-blue-700 bg-clip-text text-transparent">AION</h1>
+    <div className="sidebar" style={{ width: collapsed ? '60px' : '220px' }}>
+      {/* Logo */}
+      <div className="sidebar-logo-area">
+        {collapsed ? (
+          <div className="flex justify-center w-full">
+            <img src="/logo.svg" alt="AION" className="w-7 h-7" />
           </div>
-          <button
-            onClick={handleToggle}
-            className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
-            title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          >
-            {isCollapsed ? <FaBars className="text-gray-600" /> : <FaChevronLeft className="text-gray-600" />}
-          </button>
-        </div>
+        ) : (
+          <>
+            <div className="flex items-center gap-2.5 min-w-0">
+              <img src="/logo.svg" alt="AION" className="w-7 h-7 shrink-0" />
+              <span className="text-xl font-bold tracking-tight" style={{ color: 'var(--accent)' }}>
+                AION
+              </span>
+            </div>
+            <button
+              className="sidebar-toggle-btn shrink-0"
+              onClick={() => setCollapsed(true)}
+              title="Collapse sidebar"
+            >
+              <FaChevronLeft size={12} />
+            </button>
+          </>
+        )}
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 p-4">
-        <ul className="space-y-2">
-          {navItems.map((item) => (
-            <li key={item.name}>
-              <NavLink
-                to={item.path}
-                className={({ isActive }) =>
-                  `flex items-center ${isCollapsed ? 'justify-center' : 'space-x-3'} px-4 py-3 rounded-lg transition-colors ${
-                    isActive ? 'bg-blue-600 text-white' : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900'
-                  }`
-                }
-                title={isCollapsed ? item.name : ''}
-              >
-                <span className="text-xl flex-shrink-0">{item.icon}</span>
-                {!isCollapsed && <span className="font-medium whitespace-nowrap">{item.name}</span>}
-              </NavLink>
-            </li>
-          ))}
-        </ul>
+      <nav className="flex-1 overflow-y-auto p-2 space-y-0.5">
+        {collapsed && (
+          <button
+            className="sidebar-toggle-btn w-full flex justify-center py-2 mb-1"
+            onClick={() => setCollapsed(false)}
+            title="Expand sidebar"
+          >
+            <FaBars size={14} />
+          </button>
+        )}
+        {NAV_ITEMS.map(({ name, icon: Icon, path }) => (
+          <NavLink
+            key={path}
+            to={path}
+            end={path === '/'}
+            title={collapsed ? name : undefined}
+            className={({ isActive }) =>
+              ['sidebar-nav-item', isActive && 'active', collapsed && 'justify-center']
+                .filter(Boolean).join(' ')
+            }
+          >
+            <span className="sidebar-nav-icon"><Icon /></span>
+            {!collapsed && <span>{name}</span>}
+          </NavLink>
+        ))}
+
+        {/* MLflow external link */}
+        <div className="pt-1 mt-1" style={{ borderTop: '1px solid var(--border)' }}>
+          <a
+            href={mlflowUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Open MLflow"
+            className={['sidebar-nav-item', collapsed && 'justify-center'].filter(Boolean).join(' ')}
+          >
+            <span className="sidebar-nav-icon">
+              <FaExternalLinkAlt size={12} />
+            </span>
+            {!collapsed && (
+              <span className="flex-1 flex items-center justify-between">
+                MLflow
+                <FaExternalLinkAlt size={9} style={{ color: 'var(--text-muted)' }} />
+              </span>
+            )}
+          </a>
+        </div>
       </nav>
 
       {/* Footer */}
-      <div className="p-4 border-t border-gray-200">
-        <div className={`flex items-center ${isCollapsed ? 'justify-center px-0' : 'px-4'} py-2 gap-2`}>
-          <div className="w-8 h-8 min-w-[2rem] bg-blue-600 rounded-full flex items-center justify-center text-sm font-bold text-white flex-shrink-0">U</div>
-          {!isCollapsed && (
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-gray-900 truncate">User</p>
-              <p className="text-xs text-gray-500 truncate">Admin</p>
-            </div>
-          )}
-          <NavLink
-            to="/settings"
-            title="Settings"
-            className={({ isActive }) =>
-              `p-1.5 rounded-lg transition-colors flex-shrink-0 ${
-                isActive ? 'text-blue-600 bg-blue-50' : 'text-gray-400 hover:text-gray-600 hover:bg-gray-100'
-              }`
-            }
+      <div className="sidebar-footer">
+        <div className={`flex items-center gap-2 ${collapsed ? 'justify-center flex-col' : ''}`}>
+          <div
+            className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold shrink-0"
+            style={{ background: 'var(--accent-sub)', color: 'var(--accent)' }}
           >
-            <FaCog className="text-base" />
-          </NavLink>
+            U
+          </div>
+          {!collapsed && (
+            <>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate" style={{ color: 'var(--text-1)' }}>User</p>
+                <p className="text-xs truncate" style={{ color: 'var(--text-3)' }}>Admin</p>
+              </div>
+              <NavLink
+                to="/settings"
+                title="Settings"
+                className={({ isActive }) =>
+                  `sidebar-toggle-btn shrink-0${isActive ? ' !text-[--accent]' : ''}`
+                }
+              >
+                <FaCog size={14} />
+              </NavLink>
+            </>
+          )}
+          {collapsed && (
+            <NavLink to="/settings" title="Settings" className="sidebar-toggle-btn">
+              <FaCog size={13} />
+            </NavLink>
+          )}
         </div>
       </div>
     </div>

--- a/src/contexts/AccessibilityContext.jsx
+++ b/src/contexts/AccessibilityContext.jsx
@@ -2,21 +2,29 @@ import { createContext, useCallback, useContext, useEffect, useState } from 'rea
 
 const AccessibilityContext = createContext(null);
 
-const CVD_MODES = ['none', 'rg', 'tritan'];
-const FONT_SIZES = ['small', 'medium', 'large', 'xl'];
+const CVD_MODES   = ['none', 'rg', 'tritan'];
+const FONT_SIZES  = ['small', 'medium', 'large', 'xl'];
+const THEME_MODES = ['system', 'light', 'dark'];
 
 function getInitialPrefs() {
   const systemReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   try {
     const stored = JSON.parse(localStorage.getItem('aion-accessibility-prefs'));
     if (stored && typeof stored === 'object') return {
-      highContrast: Boolean(stored.highContrast),
-      colorVision: CVD_MODES.includes(stored.colorVision) ? stored.colorVision : 'none',
+      highContrast:  Boolean(stored.highContrast),
+      colorVision:   CVD_MODES.includes(stored.colorVision)   ? stored.colorVision   : 'none',
       reducedMotion: Boolean(stored.reducedMotion) || systemReduced,
-      fontSize: FONT_SIZES.includes(stored.fontSize) ? stored.fontSize : 'medium',
+      fontSize:      FONT_SIZES.includes(stored.fontSize)     ? stored.fontSize      : 'medium',
+      theme:         THEME_MODES.includes(stored.theme)       ? stored.theme         : 'system',
     };
   } catch { }
-  return { highContrast: false, colorVision: 'none', reducedMotion: systemReduced, fontSize: 'medium' };
+  return { highContrast: false, colorVision: 'none', reducedMotion: systemReduced, fontSize: 'medium', theme: 'system' };
+}
+
+function resolveIsDark(theme) {
+  if (theme === 'dark')  return true;
+  if (theme === 'light') return false;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
 }
 
 export const AccessibilityProvider = ({ children }) => {
@@ -24,17 +32,29 @@ export const AccessibilityProvider = ({ children }) => {
 
   useEffect(() => {
     const html = document.documentElement;
-    html.classList.toggle('high-contrast', preferences.highContrast);
-    html.classList.toggle('cvd-rg',     preferences.colorVision === 'rg');
-    html.classList.toggle('cvd-tritan', preferences.colorVision === 'tritan');
+
+    html.classList.toggle('high-contrast',  preferences.highContrast);
+    html.classList.toggle('cvd-rg',         preferences.colorVision === 'rg');
+    html.classList.toggle('cvd-tritan',     preferences.colorVision === 'tritan');
     html.classList.toggle('reduced-motion', preferences.reducedMotion);
-    html.classList.toggle('font-size-s',  preferences.fontSize === 'small');
-    html.classList.toggle('font-size-l',  preferences.fontSize === 'large');
-    html.classList.toggle('font-size-xl', preferences.fontSize === 'xl');
+    html.classList.toggle('font-size-s',    preferences.fontSize === 'small');
+    html.classList.toggle('font-size-l',    preferences.fontSize === 'large');
+    html.classList.toggle('font-size-xl',   preferences.fontSize === 'xl');
+    html.classList.toggle('dark',           resolveIsDark(preferences.theme));
+
     try {
       localStorage.setItem('aion-accessibility-prefs', JSON.stringify(preferences));
     } catch {}
   }, [preferences]);
+
+  /* React to system theme changes when mode is 'system' */
+  useEffect(() => {
+    if (preferences.theme !== 'system') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e) => document.documentElement.classList.toggle('dark', e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [preferences.theme]);
 
   const setPreference = useCallback((key, value) => {
     setPreferences(prev => ({ ...prev, [key]: value }));

--- a/src/index.css
+++ b/src/index.css
@@ -1,21 +1,326 @@
 @import "tailwindcss";
 
+/* Class-based dark mode — toggle .dark on <html> */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   --color-navy-900: #0a192f;
   --color-navy-800: #112240;
   --color-navy-700: #1a2f4a;
   --color-azure-500: #4169e1;
   --color-azure-600: #3457c9;
+  --font-sans: 'Outfit', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
 }
 
+/* ── Design tokens ────────────────────────────────────────────── */
+
+:root {
+  --bg:               #eef0f6;
+  --surface:          #ffffff;
+  --surface-2:        #f4f5fb;
+  --surface-3:        #eceef6;
+  --border:           #dde0ec;
+  --border-2:         #c8ccdd;
+  --text-1:           #1a1d2e;
+  --text-2:           #4b5068;
+  --text-3:           #8b90a8;
+  --text-muted:       #b8bdd0;
+  --accent:           #4563d6;
+  --accent-h:         #3450c4;
+  --accent-fg:        #ffffff;
+  --accent-sub:       #eef1fb;
+  --accent-sub-text:  #3450c4;
+
+  --s-green-bg:       #f0fdf4;
+  --s-green-text:     #166534;
+  --s-green-border:   #bbf7d0;
+  --s-red-bg:         #fff1f2;
+  --s-red-text:       #991b1b;
+  --s-red-border:     #fecaca;
+  --s-yellow-bg:      #fefce8;
+  --s-yellow-text:    #854d0e;
+  --s-yellow-border:  #fde68a;
+  --s-blue-bg:        #eff6ff;
+  --s-blue-text:      #1e40af;
+  --s-blue-border:    #bfdbfe;
+}
+
+.dark {
+  --bg:               #0d1017;
+  --surface:          #141920;
+  --surface-2:        #1a2130;
+  --surface-3:        #212840;
+  --border:           #262f44;
+  --border-2:         #323d58;
+  --text-1:           #e2e6f5;
+  --text-2:           #8892b0;
+  --text-3:           #536080;
+  --text-muted:       #384255;
+  --accent:           #5b77e0;
+  --accent-h:         #6a84e8;
+  --accent-fg:        #ffffff;
+  --accent-sub:       rgba(91, 119, 224, 0.14);
+  --accent-sub-text:  #8ba4ed;
+
+  --s-green-bg:       rgba(16, 185, 129, 0.08);
+  --s-green-text:     #4ade80;
+  --s-green-border:   rgba(16, 185, 129, 0.22);
+  --s-red-bg:         rgba(239, 68, 68, 0.08);
+  --s-red-text:       #f87171;
+  --s-red-border:     rgba(239, 68, 68, 0.22);
+  --s-yellow-bg:      rgba(234, 179, 8, 0.08);
+  --s-yellow-text:    #facc15;
+  --s-yellow-border:  rgba(234, 179, 8, 0.22);
+  --s-blue-bg:        rgba(59, 130, 246, 0.08);
+  --s-blue-text:      #60a5fa;
+  --s-blue-border:    rgba(59, 130, 246, 0.22);
+}
+
+/* ── Base ─────────────────────────────────────────────────────── */
+
 @layer base {
+  html {
+    font-family: 'Outfit', system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
   body {
-    background-color: #f3f4f6;
-    color: #1f2937;
+    background-color: var(--bg);
+    color: var(--text-1);
+  }
+
+  code, kbd, pre, samp {
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  }
+
+  .font-mono {
+    font-family: 'JetBrains Mono', 'Fira Code', monospace !important;
+  }
+
+  ::-webkit-scrollbar          { width: 5px; height: 5px; }
+  ::-webkit-scrollbar-track    { background: transparent; }
+  ::-webkit-scrollbar-thumb    { background: var(--border-2); border-radius: 4px; }
+  ::-webkit-scrollbar-thumb:hover { background: var(--text-3); }
+}
+
+/* ── Component classes ────────────────────────────────────────── */
+
+@layer components {
+  .page-header {
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    padding: 1rem 2rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  @media (max-width: 640px) {
+    .page-header { padding: 0.875rem 1rem; }
+  }
+  .page-header-accent {
+    width: 3px;
+    height: 1.875rem;
+    border-radius: 2px;
+    background: var(--accent);
+    flex-shrink: 0;
+  }
+  .page-header h1 {
+    font-size: 1.375rem;
+    font-weight: 600;
+    color: var(--text-1);
+    letter-spacing: -0.02em;
+    line-height: 1.3;
+  }
+  .page-header p {
+    font-size: 0.8125rem;
+    color: var(--text-3);
+    margin-top: 0.125rem;
+  }
+
+  .sidebar {
+    background: var(--surface);
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    flex-shrink: 0;
+    transition: width 0.25s ease;
+  }
+  .sidebar-logo-area {
+    padding: 1.125rem 1rem;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    min-height: 60px;
+  }
+  .sidebar-nav-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5625rem 0.875rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--text-2);
+    transition: background 0.15s, color 0.15s;
+    cursor: pointer;
+    white-space: nowrap;
+    text-decoration: none;
+  }
+  .sidebar-nav-item:hover {
+    background: var(--surface-2);
+    color: var(--text-1);
+  }
+  .sidebar-nav-item.active {
+    background: var(--accent-sub);
+    color: var(--accent);
+  }
+  .sidebar-nav-icon {
+    font-size: 1rem;
+    flex-shrink: 0;
+    color: var(--text-3);
+    transition: color 0.15s;
+  }
+  .sidebar-nav-item:hover .sidebar-nav-icon { color: var(--text-1); }
+  .sidebar-nav-item.active .sidebar-nav-icon { color: var(--accent); }
+  .sidebar-footer {
+    padding: 0.75rem;
+    border-top: 1px solid var(--border);
+  }
+  .sidebar-toggle-btn {
+    padding: 0.375rem;
+    border-radius: 0.375rem;
+    color: var(--text-3);
+    transition: background 0.15s, color 0.15s;
+    line-height: 1;
+    cursor: pointer;
+    background: transparent;
+    border: none;
+  }
+  .sidebar-toggle-btn:hover {
+    background: var(--surface-2);
+    color: var(--text-1);
   }
 }
 
-/* Reduced Motion */
+/* ── Dark mode: Tailwind utility overrides ────────────────────── */
+
+.dark .bg-white      { background-color: var(--surface) !important; }
+.dark .bg-gray-50    { background-color: var(--surface-2) !important; }
+.dark .bg-gray-100   { background-color: var(--surface-3) !important; }
+.dark .bg-gray-200   { background-color: #2a3347 !important; }
+.dark .bg-gray-300   { background-color: #374157 !important; }
+
+.dark .text-gray-950,
+.dark .text-gray-900 { color: var(--text-1) !important; }
+.dark .text-gray-800 { color: var(--text-1) !important; }
+.dark .text-gray-700 { color: var(--text-2) !important; }
+.dark .text-gray-600 { color: var(--text-2) !important; }
+.dark .text-gray-500 { color: var(--text-3) !important; }
+.dark .text-gray-400 { color: var(--text-3) !important; }
+.dark .text-gray-300 { color: var(--text-muted) !important; }
+
+.dark .border-gray-50,
+.dark .border-gray-100,
+.dark .border-gray-200 { border-color: var(--border) !important; }
+.dark .border-gray-300  { border-color: var(--border-2) !important; }
+
+.dark .divide-gray-100 > * + *,
+.dark .divide-gray-200 > * + * { border-color: var(--border) !important; }
+
+.dark .hover\:bg-gray-50:hover  { background-color: var(--surface-2) !important; }
+.dark .hover\:bg-gray-100:hover { background-color: var(--surface-3) !important; }
+.dark .hover\:bg-gray-200:hover { background-color: #2a3347 !important; }
+
+.dark .bg-blue-100 { background-color: rgba(91,119,224,0.14) !important; }
+.dark .hover\:bg-blue-100:hover { background-color: rgba(91,119,224,0.18) !important; }
+
+.dark .bg-green-50,
+.dark .bg-green-100  { background-color: var(--s-green-bg) !important; }
+.dark .bg-green-200  { background-color: rgba(16,185,129,0.15) !important; }
+.dark .text-green-600,.dark .text-green-700,
+.dark .text-green-800,.dark .text-green-900 { color: var(--s-green-text) !important; }
+.dark .border-green-200,.dark .border-green-300 { border-color: var(--s-green-border) !important; }
+.dark .ring-green-200 { --tw-ring-color: var(--s-green-border) !important; }
+
+.dark .bg-red-50,.dark .bg-red-100 { background-color: var(--s-red-bg) !important; }
+.dark .bg-red-200  { background-color: rgba(239,68,68,0.15) !important; }
+.dark .text-red-600,.dark .text-red-700,
+.dark .text-red-800,.dark .text-red-900 { color: var(--s-red-text) !important; }
+.dark .border-red-200,.dark .border-red-300 { border-color: var(--s-red-border) !important; }
+
+.dark .bg-yellow-50,.dark .bg-yellow-100 { background-color: var(--s-yellow-bg) !important; }
+.dark .bg-yellow-200 { background-color: rgba(234,179,8,0.15) !important; }
+.dark .text-yellow-600,.dark .text-yellow-700,
+.dark .text-yellow-800,.dark .text-yellow-900 { color: var(--s-yellow-text) !important; }
+.dark .border-yellow-200,.dark .border-yellow-300 { border-color: var(--s-yellow-border) !important; }
+
+.dark .bg-blue-50  { background-color: var(--s-blue-bg) !important; }
+.dark .text-blue-500,.dark .text-blue-600,
+.dark .text-blue-700,.dark .text-blue-800,
+.dark .text-blue-900 { color: var(--s-blue-text) !important; }
+.dark .border-blue-200,.dark .border-blue-300 { border-color: var(--s-blue-border) !important; }
+
+.dark .bg-purple-50,.dark .bg-purple-100 { background-color: rgba(139,92,246,0.08) !important; }
+.dark .bg-purple-200 { background-color: rgba(139,92,246,0.15) !important; }
+.dark .text-purple-600,.dark .text-purple-700,
+.dark .text-purple-800,.dark .text-purple-900 { color: #c084fc !important; }
+.dark .border-purple-200,.dark .border-purple-300 { border-color: rgba(139,92,246,0.3) !important; }
+
+.dark .bg-orange-50,.dark .bg-orange-100 { background-color: rgba(249,115,22,0.08) !important; }
+.dark .bg-orange-200 { background-color: rgba(249,115,22,0.15) !important; }
+.dark .text-orange-600,.dark .text-orange-700,
+.dark .text-orange-800,.dark .text-orange-900 { color: #fb923c !important; }
+
+.dark .bg-indigo-50,.dark .bg-indigo-100 { background-color: rgba(99,102,241,0.08) !important; }
+.dark .bg-indigo-200 { background-color: rgba(99,102,241,0.15) !important; }
+.dark .text-indigo-600,.dark .text-indigo-700,
+.dark .text-indigo-800,.dark .text-indigo-900 { color: #818cf8 !important; }
+
+.dark .bg-emerald-50,.dark .bg-emerald-100 { background-color: rgba(16,185,129,0.08) !important; }
+.dark .text-emerald-600,.dark .text-emerald-700,
+.dark .text-emerald-800 { color: #34d399 !important; }
+
+.dark .shadow-sm  { box-shadow: 0 1px 3px rgba(0,0,0,0.35) !important; }
+.dark .shadow-md  { box-shadow: 0 4px 12px rgba(0,0,0,0.45) !important; }
+.dark .shadow-lg  { box-shadow: 0 8px 24px rgba(0,0,0,0.55) !important; }
+.dark .shadow-xl  { box-shadow: 0 16px 40px rgba(0,0,0,0.65) !important; }
+
+.dark .bg-black\/20 { background-color: rgba(0,0,0,0.6) !important; }
+.dark .bg-black\/50 { background-color: rgba(0,0,0,0.75) !important; }
+
+.dark thead th          { background-color: var(--surface-2) !important; }
+.dark tbody             { background-color: var(--surface) !important; }
+.dark .bg-blue-600      { background-color: var(--accent) !important; }
+.dark .hover\:bg-blue-700:hover { background-color: var(--accent-h) !important; }
+
+.dark input[type="text"],
+.dark input[type="number"],
+.dark input[type="email"],
+.dark input[type="password"],
+.dark input[type="search"],
+.dark select,
+.dark textarea {
+  background-color: var(--surface-3) !important;
+  color: var(--text-1) !important;
+  border-color: var(--border-2) !important;
+}
+.dark input::placeholder,
+.dark textarea::placeholder { color: var(--text-muted) !important; }
+.dark input[type="checkbox"] {
+  background-color: var(--surface-3);
+  border-color: var(--border-2);
+}
+
+.dark .focus\:ring-blue-500:focus   { --tw-ring-color: rgba(91,119,224,0.45) !important; }
+.dark .focus\:border-blue-500:focus { border-color: var(--accent) !important; }
+
+/* ── Accessibility (preserved) ────────────────────────────────── */
+
 html.reduced-motion *,
 html.reduced-motion *::before,
 html.reduced-motion *::after {
@@ -29,46 +334,39 @@ html.reduced-motion *::after {
   }
 }
 
-/* Mode 1: Red-Green safe (Deuteranopia + Protanopia) */
 html.cvd-rg [class*="text-green-"]   { color: #005fa3 !important; }
 html.cvd-rg [class*="bg-green-50"]   { background-color: #e8f4fd !important; }
 html.cvd-rg [class*="bg-green-100"]  { background-color: #cce5f6 !important; }
 html.cvd-rg [class*="bg-green-500"],
 html.cvd-rg [class*="bg-green-600"]  { background-color: #0077bb !important; }
 html.cvd-rg [class*="border-green-"] { border-color: #0077bb !important; }
-
 html.cvd-rg [class*="text-red-"]     { color: #c43b00 !important; }
 html.cvd-rg [class*="bg-red-50"]     { background-color: #fff3ee !important; }
 html.cvd-rg [class*="bg-red-100"]    { background-color: #fdd9c8 !important; }
 html.cvd-rg [class*="bg-red-500"],
 html.cvd-rg [class*="bg-red-600"]    { background-color: #ee7733 !important; }
 html.cvd-rg [class*="border-red-"]   { border-color: #ee7733 !important; }
-
 html.cvd-rg [class*="text-orange-"]  { color: #005fa3 !important; }
 html.cvd-rg [class*="bg-orange-100"] { background-color: #cce5f6 !important; }
 html.cvd-rg [class*="bg-orange-500"],
 html.cvd-rg [class*="bg-orange-600"] { background-color: #0077bb !important; }
 html.cvd-rg [class*="border-orange-"]{ border-color: #0077bb !important; }
 
-/* Mode 2: Tritanopia safe (Blue-Yellow) */
 html.cvd-tritan [class*="text-yellow-"]   { color: #b0004e !important; }
 html.cvd-tritan [class*="bg-yellow-50"]   { background-color: #fce4ec !important; }
 html.cvd-tritan [class*="bg-yellow-100"]  { background-color: #f8bbd0 !important; }
 html.cvd-tritan [class*="border-yellow-"] { border-color: #d81b60 !important; }
-
 html.cvd-tritan [class*="text-purple-"]   { color: #bf360c !important; }
 html.cvd-tritan [class*="bg-purple-50"]   { background-color: #fbe9e7 !important; }
 html.cvd-tritan [class*="bg-purple-100"]  { background-color: #ffccbc !important; }
 html.cvd-tritan [class*="bg-purple-600"]  { background-color: #f4511e !important; }
 html.cvd-tritan [class*="border-purple-"] { border-color: #f4511e !important; }
-
 html.cvd-tritan [class*="text-orange-"]   { color: #b0004e !important; }
 html.cvd-tritan [class*="bg-orange-100"]  { background-color: #f8bbd0 !important; }
 html.cvd-tritan [class*="bg-orange-500"],
 html.cvd-tritan [class*="bg-orange-600"]  { background-color: #d81b60 !important; }
 html.cvd-tritan [class*="border-orange-"] { border-color: #d81b60 !important; }
 
-/* High Contrast */
 html.high-contrast {
   --hc-bg: #ffffff;
   --hc-fg: #000000;
@@ -89,7 +387,6 @@ html.high-contrast * {
   box-shadow: none !important;
   text-shadow: none !important;
 }
-
 html.high-contrast [class*="bg-green-"],
 html.high-contrast [class*="bg-red-"],
 html.high-contrast [class*="bg-yellow-"],
@@ -98,7 +395,6 @@ html.high-contrast [class*="bg-purple-"] {
   background-color: var(--hc-bg) !important;
   border: 1px solid var(--hc-border) !important;
 }
-
 html.high-contrast .bg-blue-600,
 html.high-contrast .bg-blue-500,
 html.high-contrast .bg-indigo-600,
@@ -112,7 +408,6 @@ html.high-contrast .bg-orange-600 {
   color: #fff !important;
   border: 2px solid #000 !important;
 }
-
 html.high-contrast [class*="from-blue-"],
 html.high-contrast [class*="from-green-"],
 html.high-contrast [class*="from-red-"] {
@@ -121,8 +416,6 @@ html.high-contrast [class*="from-red-"] {
   color: #fff !important;
   border: 2px solid #000 !important;
 }
-
-/* Exception for gradient text (logo) - must come after the above rule */
 html.high-contrast [class*="from-blue-"].bg-clip-text,
 html.high-contrast [class*="from-green-"].bg-clip-text,
 html.high-contrast [class*="from-red-"].bg-clip-text,
@@ -137,16 +430,9 @@ html.high-contrast [class*="text-green-"],
 html.high-contrast [class*="text-red-"],
 html.high-contrast [class*="text-yellow-"],
 html.high-contrast [class*="text-blue-"],
-html.high-contrast [class*="text-gray-"] {
-  color: var(--hc-fg) !important;
-}
-html.high-contrast header {
-  background: #000 !important;
-  border-bottom: 2px solid #000 !important;
-}
-html.high-contrast [class*="border-"] {
-  border-color: var(--hc-border) !important;
-}
+html.high-contrast [class*="text-gray-"] { color: var(--hc-fg) !important; }
+html.high-contrast header { background: #000 !important; border-bottom: 2px solid #000 !important; }
+html.high-contrast [class*="border-"] { border-color: var(--hc-border) !important; }
 html.high-contrast .bg-clip-text,
 html.high-contrast .text-transparent {
   -webkit-background-clip: unset !important;
@@ -156,18 +442,10 @@ html.high-contrast .text-transparent {
   border: none !important;
   color: #000000 !important;
 }
-
 html.high-contrast header,
-html.high-contrast header * {
-  color: #fff !important;
-}
-
-/* Override header text color for logo */
+html.high-contrast header * { color: #fff !important; }
 html.high-contrast .bg-clip-text,
-html.high-contrast .text-transparent {
-  color: #000000 !important;
-}
-
+html.high-contrast .text-transparent { color: #000000 !important; }
 html.high-contrast .bg-blue-600,    html.high-contrast .bg-blue-600 *,
 html.high-contrast .bg-blue-500,    html.high-contrast .bg-blue-500 *,
 html.high-contrast .bg-green-600,   html.high-contrast .bg-green-600 *,
@@ -181,14 +459,10 @@ html.high-contrast [class*="from-blue-"], html.high-contrast [class*="from-blue-
   color: #fff !important;
 }
 
-/* Font Size */
 html.font-size-s  { font-size: 13px; }
 html.font-size-l  { font-size: 19px; }
 html.font-size-xl { font-size: 22px; }
 
-/* ML Model card - responsive header */
 @container (max-width: 18rem) {
-  .model-card-actions {
-    flex: 0 0 100%;
-  }
+  .model-card-actions { flex: 0 0 100%; }
 }

--- a/src/pages/Analytics.jsx
+++ b/src/pages/Analytics.jsx
@@ -2,53 +2,50 @@ import React, { useState, useEffect } from 'react';
 import SearchableDropdown from '../components/SearchableDropdown';
 import FeatureImportanceChart from '../components/FeatureImportanceChart';
 
+const fmtTs = (epoch) => epoch ? new Date(epoch * 1000).toLocaleString() : 'N/A';
+
 const Analytics = () => {
-  const dataStorageUrl ='/' + import.meta.env.VITE_DATA_STORAGE_HOST;
   const mlUrl = '/' + import.meta.env.VITE_ML_HOST;
+  const dataStorageUrl = '/' + import.meta.env.VITE_DATA_STORAGE_HOST;
 
   const [formData, setFormData] = useState({
     output_field: '',
-    cell_index: 26379009,
+    snssai_sst: '',
+    dnn: '',
+    snssai_sd: '',
     model_id: null,
+    lookback_seconds: 1800,
   });
 
   const [prediction, setPrediction] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [cellList, setCellList] = useState([]);
-  const [loadingCells, setLoadingCells] = useState(true);
+  const [explain, setExplain] = useState(false);
 
   const [fields, setFields] = useState([]);
   const [loadingFields, setLoadingFields] = useState(true);
   const [fieldsWithModels, setFieldsWithModels] = useState(new Set());
-
+  const [fieldEventMap, setFieldEventMap] = useState({});  // {field: [events]}
   const [models, setModels] = useState([]);
   const [loadingModels, setLoadingModels] = useState(false);
 
-  const [explain, setExplain] = useState(false);
+  const isAnomaly = formData.output_field === 'anomaly';
 
-  // Fetch available cells on mount
+  // Derive event from selected field (first from intersection, or first from field's events)
+  const derivedEvent = (() => {
+    if (isAnomaly || !formData.output_field) return null;
+    const events = fieldEventMap[formData.output_field];
+    return events?.length > 0 ? events[0] : null;
+  })();
+
+  // Fetch field→event map from data-storage
   useEffect(() => {
-    const fetchCells = async () => {
-      try {
-        const response = await fetch(`${dataStorageUrl}/api/v1/cell`);
-        if (response.ok) {
-          const data = await response.json();
-          setCellList(data);
-          if (data.length > 0 && !formData.cell_index) {
-            setFormData(prev => ({ ...prev, cell_index: data[0] }));
-          }
-        } else {
-          throw new Error(`Server responded with status: ${response.status}`);
-        }
-      } finally {
-        setLoadingCells(false);
-      }
-    };
-    fetchCells();
+    fetch(`${dataStorageUrl}/api/v1/processed/fields`)
+      .then(r => r.ok ? r.json() : {})
+      .then(data => setFieldEventMap(typeof data === 'object' && !Array.isArray(data) ? data : {}))
+      .catch(() => {});
   }, []);
 
-  // Fetch available output fields on mount (with model status)
   useEffect(() => {
     const fetchFields = async () => {
       try {
@@ -56,20 +53,10 @@ const Analytics = () => {
         if (!response.ok) return;
         const data = await response.json();
         const fieldList = (data.fields ?? []).map(f => f.name);
-
-        // Add anomaly as a special field
         const allFields = ['anomaly', ...fieldList];
         setFields(allFields);
-
-        // Don't add anomaly to fieldsWithModels - it's a special case
-        const fieldsWithModelsSet = new Set(
-          (data.fields ?? []).filter(f => f.has_models).map(f => f.name)
-        );
-        setFieldsWithModels(fieldsWithModelsSet);
-
-        if (allFields.length > 0) {
-          setFormData(prev => ({ ...prev, output_field: allFields[0] }));
-        }
+        setFieldsWithModels(new Set((data.fields ?? []).filter(f => f.has_models).map(f => f.name)));
+        if (allFields.length > 0) setFormData(prev => ({ ...prev, output_field: allFields[0] }));
       } finally {
         setLoadingFields(false);
       }
@@ -77,38 +64,22 @@ const Analytics = () => {
     fetchFields();
   }, []);
 
-  // Fetch models when output_field changes, only if that field has trained models
   useEffect(() => {
     if (!formData.output_field) return;
-
     setModels([]);
     setFormData(prev => ({ ...prev, model_id: null }));
-
-    // Skip fetching models for anomaly - it always uses best model
-    if (formData.output_field === 'anomaly') return;
-
-    if (!fieldsWithModels.has(formData.output_field)) return;
-
+    if (isAnomaly || !fieldsWithModels.has(formData.output_field)) return;
     const fetchModels = async () => {
       setLoadingModels(true);
       try {
-        const response = await fetch(
-          `${mlUrl}/v1/models?output_field=${encodeURIComponent(formData.output_field)}`
-        );
-        if (response.ok) {
-          const data = await response.json();
-          setModels(data);
-        }
+        const response = await fetch(`${mlUrl}/v1/models?output_field=${encodeURIComponent(formData.output_field)}`);
+        if (response.ok) setModels(await response.json());
       } finally {
         setLoadingModels(false);
       }
     };
     fetchModels();
   }, [formData.output_field, fieldsWithModels]);
-
-  const handleFieldChange = (e) => {
-    setFormData(prev => ({ ...prev, output_field: e.target.value }));
-  };
 
   const fetchPrediction = async (e) => {
     e.preventDefault();
@@ -117,19 +88,17 @@ const Analytics = () => {
     setPrediction(null);
 
     try {
-      // Use different endpoint for anomaly detection
-      const endpoint = formData.output_field === 'anomaly'
-        ? `${mlUrl}/v1/anomaly/detect/all`
-        : `${mlUrl}/v1/inference`;
+      const tags = {
+        snssai_sst: formData.snssai_sst,
+        dnn: formData.dnn,
+        ...(formData.snssai_sd ? { snssai_sd: formData.snssai_sd } : {}),
+        ...(derivedEvent ? { event: derivedEvent } : {}),
+      };
 
-      const body = formData.output_field === 'anomaly'
-        ? { cell_id: formData.cell_index }
-        : {
-            output_field: formData.output_field,
-            cell_id: formData.cell_index,
-            model_id: formData.model_id,
-            explain,
-          };
+      const endpoint = isAnomaly ? `${mlUrl}/v1/anomaly/detect` : `${mlUrl}/v1/inference`;
+      const body = isAnomaly
+        ? { tags, model_id: formData.model_id || undefined, lookback_seconds: formData.lookback_seconds, explain }
+        : { output_field: formData.output_field, tags, model_id: formData.model_id, explain };
 
       const response = await fetch(endpoint, {
         method: 'POST',
@@ -141,48 +110,25 @@ const Analytics = () => {
         let errMsg;
         try {
           const errBody = await response.json();
-
-          // Parse error detail from backend
           if (errBody.detail) {
             if (Array.isArray(errBody.detail)) {
-              // Pydantic validation errors
-              errMsg = errBody.detail.map(d => {
-                const field = d.loc?.slice(1).join('.') || 'input';
-                return `${field}: ${d.msg}`;
-              }).join('; ');
+              errMsg = errBody.detail.map(d => `${d.loc?.slice(1).join('.') || 'input'}: ${d.msg}`).join('; ');
             } else if (typeof errBody.detail === 'object' && errBody.detail.message) {
-              // Structured error with message
               errMsg = errBody.detail.message;
             } else {
-              // Simple string error
               errMsg = errBody.detail;
             }
           } else {
-            // Fallback messages when no detail provided
-            switch (response.status) {
-              case 404:
-                errMsg = 'Resource not found. The requested model or data does not exist.';
-                break;
-              case 422:
-                errMsg = 'Validation error. Please check your input parameters.';
-                break;
-              case 500:
-                errMsg = 'Internal server error. Please try again later.';
-                break;
-              default:
-                errMsg = `Request failed with status ${response.status}`;
-            }
+            errMsg = `Request failed with status ${response.status}`;
           }
-        } catch (parseError) {
-          // Failed to parse error response
-          errMsg = `Request failed with status ${response.status}. Unable to parse error details.`;
+        } catch {
+          errMsg = `Request failed with status ${response.status}`;
         }
         setError(errMsg);
         return;
       }
 
-      const data = await response.json();
-      setPrediction(data);
+      setPrediction(await response.json());
     } catch (err) {
       setError(`Failed to fetch prediction: ${err.message}`);
     } finally {
@@ -190,373 +136,308 @@ const Analytics = () => {
     }
   };
 
-  const noModelsAvailable = !loadingModels && models.length === 0 && formData.output_field && formData.output_field !== 'anomaly';
+  const noModelsAvailable = !loadingModels && models.length === 0 && formData.output_field && !isAnomaly;
 
   return (
     <div className="space-y-6">
-      {/* Header */}
       <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">Analytics Predictions</h2>
-        <p className="text-sm text-gray-600">
-          Get ML predictions for network metrics including latency, throughput and more
-        </p>
+        <h2 className="text-2xl font-bold text-gray-900 mb-1">Analytics Predictions</h2>
+        <p className="text-sm text-gray-500">Run forecast or anomaly detection on network data</p>
       </div>
 
-      {/* Request Form */}
+      {/* Form */}
       <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
         <h3 className="text-lg font-semibold text-gray-900 mb-4">Request Parameters</h3>
         <form onSubmit={fetchPrediction} className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {/* Output Field */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                Output Field
-              </label>
+              <div className="flex items-center gap-2 mb-2">
+                <label className="block text-sm font-medium text-gray-700">Output Field</label>
+                {derivedEvent && (
+                  <span className="px-2 py-0.5 text-xs font-bold rounded uppercase bg-blue-100 text-blue-800">{derivedEvent}</span>
+                )}
+              </div>
               <SearchableDropdown
                 options={fields}
                 value={formData.output_field}
-                onChange={(field) => handleFieldChange({ target: { value: field } })}
-                placeholder={loadingFields ? 'Loading...' : fields.length > 0 ? 'Search fields...' : 'No fields available'}
+                onChange={(field) => setFormData(prev => ({ ...prev, output_field: field }))}
+                placeholder={loadingFields ? 'Loading...' : 'Search fields...'}
                 disabled={loadingFields}
                 loading={loadingFields}
                 recentSearchKey="analytics-fields"
-                formatOption={(f) => {
-                  if (f === 'anomaly') return 'Anomaly Detection';
-                  return fieldsWithModels.has(f) ? f : `${f} (no model)`;
-                }}
-                filterOption={(f, term) => {
-                  const label = f === 'anomaly' ? 'anomaly detection' : f;
-                  return label.toLowerCase().includes(term.toLowerCase());
-                }}
+                formatOption={(f) => f === 'anomaly' ? 'Anomaly Detection' : fieldsWithModels.has(f) ? f : `${f} (no model)`}
+                filterOption={(f, term) => (f === 'anomaly' ? 'anomaly detection' : f).toLowerCase().includes(term.toLowerCase())}
               />
             </div>
 
-            {/* Cell ID */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                Cell ID {cellList.length > 0 && `(${cellList.length} available)`}
-              </label>
-              <SearchableDropdown
-                options={cellList}
-                value={formData.cell_index}
-                onChange={(cell) => setFormData(prev => ({ ...prev, cell_index: cell }))}
-                placeholder={loadingCells ? "Loading cells..." : cellList.length > 0 ? "Search or select a cell..." : "Enter cell ID manually"}
-                disabled={loadingCells}
-                loading={loadingCells}
-                recentSearchKey="analytics-cells"
-                formatOption={(cell) => cell.toString()}
-                filterOption={(cell, searchTerm) => cell.toString().startsWith(searchTerm)}
-              />
+            {/* Network Tags */}
+            <div className="space-y-2">
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">S-NSSAI SST <span className="text-red-500">*</span></label>
+                  <input type="text" className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm" placeholder="e.g. 1" value={formData.snssai_sst} onChange={e => setFormData(prev => ({ ...prev, snssai_sst: e.target.value }))} required />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">DNN <span className="text-red-500">*</span></label>
+                  <input type="text" className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm" placeholder="e.g. internet" value={formData.dnn} onChange={e => setFormData(prev => ({ ...prev, dnn: e.target.value }))} required />
+                </div>
+              </div>
+              <input type="text" className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm" placeholder="S-NSSAI SD (optional)" value={formData.snssai_sd} onChange={e => setFormData(prev => ({ ...prev, snssai_sd: e.target.value }))} />
             </div>
 
-            {/* HORIZON - commented out, may be re-enabled later */}
-            {/*
+            {/* Model */}
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
-                Horizon (seconds)
-              </label>
-              <select
-                name="horizon"
-                value={formData.horizon}
-                onChange={handleInputChange}
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
-                disabled={configLoading}
-              >
-                {configLoading ? (
-                  <option>Loading...</option>
-                ) : config?.inference_types ? (
-                  config.inference_types
-                    .filter(t => t.name === formData.analytics_type)
-                    .map(t => (
-                      <option key={`${t.name}-${t.horizon}`} value={t.horizon}>
-                        {t.horizon}s - {t.description}
-                      </option>
-                    ))
-                ) : (
-                  <>
-                    <option value={60}>60s</option>
-                    <option value={300}>300s</option>
-                  </>
-                )}
-              </select>
-            </div>
-            */}
-
-            {/* Model (optional) */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                Model {formData.output_field !== 'anomaly' && <span className="text-gray-400 font-normal">(optional)</span>}
+                Model <span className="text-gray-400 font-normal">(optional)</span>
               </label>
               <SearchableDropdown
-                options={formData.output_field === 'anomaly' ? [null] : [null, ...models.map(m => m.id)]}
+                options={[null, ...models.map(m => m.id)]}
                 value={formData.model_id}
                 onChange={(id) => setFormData(prev => ({ ...prev, model_id: id }))}
-                placeholder={loadingModels ? 'Loading models...' : 'Search models...'}
-                disabled={formData.output_field === 'anomaly' || loadingModels || noModelsAvailable}
+                placeholder={loadingModels ? 'Loading models...' : 'Best model (auto)'}
+                disabled={loadingModels || noModelsAvailable}
                 loading={loadingModels}
                 recentSearchKey="analytics-models"
                 formatOption={(id) => {
-                  if (id === null || id === undefined) return 'Best model (auto)';
+                  if (!id) return 'Best model (auto)';
                   const m = models.find(m => m.id === id);
-                  return m ? `${m.name} – ${m.id}` : id;
+                  return m ? `${m.name} – ${m.id.slice(0, 8)}` : id;
                 }}
                 filterOption={(id, term) => {
-                  if (id === null || id === undefined) return 'best model auto'.includes(term.toLowerCase());
+                  if (!id) return 'best model auto'.includes(term.toLowerCase());
                   const m = models.find(m => m.id === id);
-                  const label = m ? `${m.name} ${m.id}` : id;
-                  return label.toLowerCase().includes(term.toLowerCase());
+                  return (m ? `${m.name} ${m.id}` : id).toLowerCase().includes(term.toLowerCase());
                 }}
               />
-              {formData.output_field === 'anomaly' && (
-                <p className="mt-1 text-sm text-blue-700">
-                  Anomaly detection uses the best available model.
-                </p>
-              )}
-              {noModelsAvailable && formData.output_field !== 'anomaly' && (
-                <p className="mt-1 text-sm text-yellow-700">
-                  No trained models available for this field.
-                </p>
-              )}
+              {noModelsAvailable && <p className="mt-1 text-xs text-yellow-700">No trained models for this field.</p>}
             </div>
 
-            {formData.output_field !== 'anomaly' && (
-              <div className="flex items-end pb-1 md:col-start-2">
-                <label className="flex items-center gap-2 cursor-pointer">
+            {/* Lookback (anomaly) / Explain (both) */}
+            <div className="space-y-3">
+              {isAnomaly && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Lookback <span className="text-gray-400 font-normal text-xs">(seconds, default 30min)</span>
+                  </label>
                   <input
-                    type="checkbox"
-                    checked={explain}
-                    onChange={e => setExplain(e.target.checked)}
-                    disabled={noModelsAvailable}
-                    className="w-5 h-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 disabled:opacity-50"
+                    type="number" min="60" max="2592000"
+                    value={formData.lookback_seconds}
+                    onChange={e => { const v = parseInt(e.target.value); if (!isNaN(v)) setFormData(prev => ({ ...prev, lookback_seconds: Math.min(Math.max(60, v), 2592000) })); }}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
                   />
-                  <span className="text-base text-gray-700">Include local explanation (KernelSHAP)</span>
-                </label>
-              </div>
-            )}
+                </div>
+              )}
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={explain}
+                  onChange={e => setExplain(e.target.checked)}
+                  disabled={noModelsAvailable}
+                  className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 disabled:opacity-50"
+                />
+                <span className="text-sm text-gray-700">
+                  Include local explanation (KernelSHAP)
+                  {isAnomaly && <span className="ml-1 text-xs text-gray-400">— anomalous windows only</span>}
+                </span>
+              </label>
+            </div>
           </div>
 
-          {/* Submit Button */}
           <button
             type="submit"
-            disabled={loading || noModelsAvailable}
-            className="w-full px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={loading || (!isAnomaly && noModelsAvailable) || !formData.snssai_sst.trim() || !formData.dnn.trim()}
+            className="w-full px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
           >
-            {loading ? (
-              <span className="flex items-center justify-center">
-                <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                </svg>
-                Fetching Prediction...
-              </span>
-            ) : (
-              'Get Prediction'
-            )}
+            {loading && <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/></svg>}
+            {loading ? 'Fetching...' : isAnomaly ? 'Run Anomaly Detection' : 'Get Prediction'}
           </button>
         </form>
       </div>
 
-      {/* Error Display */}
+      {/* Error */}
       {error && (
         <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-          <div className="flex items-start space-x-3">
-            <div>
-              <p className="font-semibold text-red-900 mb-1">Error</p>
-              <p className="text-sm text-red-800">{error}</p>
-            </div>
-          </div>
+          <p className="font-semibold text-red-900 mb-1">Error</p>
+          <p className="text-sm text-red-800">{error}</p>
         </div>
       )}
 
-      {/* Prediction Results */}
+      {/* Results */}
       {prediction && (
         <div className="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
           <div className="px-6 py-4 border-b border-gray-200 bg-gradient-to-r from-green-50 to-blue-50">
-            <h3 className="text-lg font-semibold text-gray-900">
-              {formData.output_field === 'anomaly' ? 'Anomaly Detection Results' : 'Prediction Results'}
-            </h3>
-            <p className="text-sm text-gray-600">Inference for Cell ID: {formData.cell_index}</p>
+            <h3 className="text-lg font-semibold text-gray-900">{isAnomaly ? 'Anomaly Detection Results' : 'Prediction Results'}</h3>
+            <p className="text-sm text-gray-500">
+              sst={formData.snssai_sst} dnn={formData.dnn}{formData.snssai_sd ? ` sd=${formData.snssai_sd}` : ''}
+            </p>
           </div>
 
           <div className="p-6 space-y-6">
-            {/* Model info + timing summary - forecast only */}
-            {formData.output_field !== 'anomaly' && (
-            <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
-              <dl className="space-y-2 text-sm">
+
+            {/* ── FORECAST ── */}
+            {!isAnomaly && <>
+              <div className="bg-gray-50 rounded-lg p-4 border border-gray-200 text-sm space-y-1.5">
                 <div className="flex gap-2">
-                  <dt className="w-32 text-gray-500 shrink-0">Model</dt>
-                  <dd className="text-gray-900 font-medium">
-                    {prediction.model_name} (v{prediction.model_version}{prediction.architecture && `, ${prediction.architecture}`})
-                    {prediction.model_id && (
-                      <span className="ml-2 text-gray-400 font-normal text-xs">{prediction.model_id}</span>
-                    )}
-                  </dd>
-                </div>
-                {formData.output_field !== 'anomaly' && (
-                  <>
-                    <div className="flex gap-2">
-                      <dt className="w-32 text-gray-500 shrink-0">Lookahead</dt>
-                      <dd className="text-gray-900">
-                        {prediction.forecast_steps} steps x {prediction.window_duration_seconds}s
-                        {' '}= <span className="font-medium">{prediction.forecast_steps * prediction.window_duration_seconds}s total</span>
-                      </dd>
-                    </div>
-                    <div className="flex gap-2">
-                      <dt className="w-32 text-gray-500 shrink-0">Input data</dt>
-                      <dd className="text-gray-900">
-                        {prediction.input_data_start && prediction.input_data_end ? (
-                          <>
-                            <span className="font-mono text-xs">
-                              {new Date(prediction.input_data_start * 1000).toLocaleString()}
-                            </span>
-                            {' '}&rarr;{' '}
-                            <span className="font-mono text-xs">
-                              {new Date(prediction.input_data_end * 1000).toLocaleString()}
-                            </span>
-                            <span className="ml-2 text-gray-500">
-                              ({prediction.lookback_steps} windows, {((prediction.input_data_end - prediction.input_data_start) / 1).toFixed(0)}s duration)
-                            </span>
-                          </>
-                        ) : (
-                          <span>{prediction.lookback_steps} x {prediction.window_duration_seconds}s lookback</span>
-                        )}
-                      </dd>
-                    </div>
-                    {prediction.window_overlap != null && (
-                      <div className="flex gap-2">
-                        <dt className="w-32 text-gray-500 shrink-0">Window overlap</dt>
-                        <dd className="text-gray-900">
-                          <span className="font-medium">{prediction.window_overlap}s</span>
-                          <span className="ml-2 text-gray-500">
-                            (step size: {prediction.window_duration_seconds - prediction.window_overlap}s)
-                          </span>
-                        </dd>
-                      </div>
-                    )}
-                  </>
-                )}
-              </dl>
-            </div>
-            )}
-
-            {/* Anomaly Detection Summary - IP rows, model columns */}
-            {formData.output_field === 'anomaly' && prediction?.ip_anomalies && (() => {
-              const modelNames = Object.keys(prediction.models ?? {});
-              const rows = Object.entries(prediction.ip_anomalies);
-              return (
-                <div className="border border-gray-200 rounded-lg overflow-hidden">
-                  {/* Model metadata header */}
-                  <div className="px-4 py-3 bg-gray-50 border-b border-gray-200 space-y-1">
-                    {modelNames.map(id => {
-                      const m = prediction.models[id];
-                      return (
-                        <div key={id} className="flex flex-wrap gap-x-4 text-sm">
-                          <span className="font-semibold text-gray-800">{m.name}</span>
-                          <span className="text-gray-500">window: {m.window_duration_seconds}s</span>
-                          <span className="text-gray-500">threshold: <span className="font-mono">{m.threshold?.toFixed(4)}</span></span>
-                          <span className="text-gray-400 text-xs self-center">{m.fields?.join(', ')}</span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                  <div className="overflow-x-auto"><table className="w-full text-sm">
-                    <thead className="bg-gray-50 border-b border-gray-200">
-                      <tr>
-                        <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">IP Address</th>
-                        {modelNames.map(id => (
-                          <th key={id} className="px-4 py-2 text-right text-xs font-semibold text-gray-500 uppercase tracking-wide">{prediction.models[id].name}</th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-100">
-                      {rows.map(([ip, modelCounts]) => (
-                        <tr key={ip} className="hover:bg-gray-50">
-                          <td className="px-4 py-2 text-gray-900 font-mono text-xs">{ip}</td>
-                          {modelNames.map(id => {
-                            const val = modelCounts[id] ?? '-';
-                            const [anom, total] = val.split('/').map(Number);
-                            const isAnomaly = anom > 0;
-                            return (
-                              <td key={id} className={`px-4 py-2 text-right font-mono ${isAnomaly ? 'text-red-600 font-semibold' : 'text-gray-500'}`}>
-                                {val}
-                              </td>
-                            );
-                          })}
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table></div>
-                </div>
-              );
-            })()}
-
-            {/* Forecast Predictions list */}
-            {formData.output_field !== 'anomaly' && prediction.predictions?.length > 0 && (
-              <div>
-                <h4 className="text-sm font-semibold text-gray-700 mb-3">
-                  Predictions - <span className="font-normal text-gray-500">{formData.output_field}</span>
-                </h4>
-                <div className="border border-gray-200 rounded-lg overflow-hidden">
-                  <table className="w-full text-sm">
-                    <thead className="bg-gray-50 border-b border-gray-200">
-                      <tr>
-                        <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Step</th>
-                        <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Window Start</th>
-                        <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Window End</th>
-                        <th className="px-4 py-2 text-right text-xs font-semibold text-gray-500 uppercase tracking-wide">Value</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-100">
-                      {prediction.predictions.map((p) => (
-                        <tr key={p.step} className="hover:bg-gray-50">
-                          <td className="px-4 py-2 text-gray-600">
-                            {p.step}
-                          </td>
-                          <td className="px-4 py-2 text-gray-700 font-mono text-xs">
-                            {p.window_start_time
-                              ? new Date(p.window_start_time * 1000).toLocaleString()
-                              : 'N/A'}
-                          </td>
-                          <td className="px-4 py-2 text-gray-700 font-mono text-xs">
-                            {p.window_end_time
-                              ? new Date(p.window_end_time * 1000).toLocaleString()
-                              : 'N/A'}
-                          </td>
-                          <td className="px-4 py-2 text-right font-mono text-gray-900">
-                            {p.values[formData.output_field] != null
-                              ? p.values[formData.output_field].toFixed(4)
-                              : 'N/A'}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            )}
-
-            {/* Local Explanation (KernelSHAP) */}
-            {prediction.explanation && (
-              <div>
-                <div className="flex items-center gap-2 mb-3">
-                  <h4 className="text-sm font-semibold text-gray-700">Local Explanation</h4>
-                  <span className="px-2 py-0.5 text-xs font-bold bg-gray-100 text-gray-600 rounded uppercase tracking-wide">
-                    {prediction.explanation.method}
+                  <span className="w-28 text-gray-500 shrink-0">Model</span>
+                  <span className="font-medium text-gray-900">
+                    {prediction.model_name} (v{prediction.model_version}{prediction.architecture ? `, ${prediction.architecture}` : ''})
+                    <span className="ml-2 text-gray-400 font-normal text-xs">{prediction.model_id}</span>
                   </span>
                 </div>
-                <p className="text-xs text-gray-500 mb-4">
-                  Baseline: <span className="font-mono font-medium text-gray-700">{prediction.explanation.baseline?.toFixed(4)}</span>
-                  {' · '}Positive values pushed the prediction above baseline, negative below.
-                </p>
-                <FeatureImportanceChart
-                  importances={Object.fromEntries(
-                    Object.entries(prediction.explanation.attributions).map(([k, v]) => [k, { mean: v }])
-                  )}
-                  metric="shap"
-                  computedAt={prediction.explanation.computed_at}
-                />
+                <div className="flex gap-2">
+                  <span className="w-28 text-gray-500 shrink-0">Lookahead</span>
+                  <span>{prediction.forecast_steps} steps × {prediction.window_duration_seconds}s = <strong>{prediction.forecast_steps * prediction.window_duration_seconds}s</strong></span>
+                </div>
+                <div className="flex gap-2">
+                  <span className="w-28 text-gray-500 shrink-0">Input data</span>
+                  <span className="font-mono text-xs">
+                    {fmtTs(prediction.input_data_start)} → {fmtTs(prediction.input_data_end)}
+                    <span className="ml-2 text-gray-400">({prediction.lookback_steps} windows)</span>
+                  </span>
+                </div>
               </div>
-            )}
+
+              {prediction.predictions?.length > 0 && (
+                <div>
+                  <h4 className="text-sm font-semibold text-gray-700 mb-2">Predictions — <span className="font-normal text-gray-500">{formData.output_field}</span></h4>
+                  <div className="border border-gray-200 rounded-lg overflow-hidden">
+                    <table className="w-full text-sm">
+                      <thead className="bg-gray-50 border-b border-gray-200">
+                        <tr>
+                          <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase">Step</th>
+                          <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase">Window Start</th>
+                          <th className="px-4 py-2 text-left text-xs font-semibold text-gray-500 uppercase">Window End</th>
+                          <th className="px-4 py-2 text-right text-xs font-semibold text-gray-500 uppercase">Value</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {prediction.predictions.map(p => (
+                          <tr key={p.step} className="hover:bg-gray-50">
+                            <td className="px-4 py-2 text-gray-600">{p.step}</td>
+                            <td className="px-4 py-2 text-gray-700 font-mono text-xs">{fmtTs(p.window_start_time)}</td>
+                            <td className="px-4 py-2 text-gray-700 font-mono text-xs">{fmtTs(p.window_end_time)}</td>
+                            <td className="px-4 py-2 text-right font-mono text-gray-900">
+                              {p.values[formData.output_field] != null ? p.values[formData.output_field].toFixed(4) : 'N/A'}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+
+              {prediction.explanation && (
+                <div>
+                  <div className="flex items-center gap-2 mb-2">
+                    <h4 className="text-sm font-semibold text-gray-700">Local Explanation</h4>
+                    <span className="px-2 py-0.5 text-xs font-bold bg-gray-100 text-gray-600 rounded uppercase">{prediction.explanation.method}</span>
+                  </div>
+                  <p className="text-xs text-gray-500 mb-3">Baseline: <span className="font-mono font-medium text-gray-700">{prediction.explanation.baseline?.toFixed(4)}</span> · Positive = pushed above baseline.</p>
+                  <FeatureImportanceChart
+                    importances={Object.fromEntries(Object.entries(prediction.explanation.attributions).map(([k, v]) => [k, { mean: v }]))}
+                    metric="shap"
+                    computedAt={prediction.explanation.computed_at}
+                  />
+                </div>
+              )}
+            </>}
+
+            {/* ── ANOMALY ── */}
+            {isAnomaly && (() => {
+              const models = prediction.models ?? {};
+              const counts = prediction.anomaly_counts ?? {};
+              const results = prediction.results ?? [];
+
+              return <>
+                {/* Model summary cards */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  {Object.entries(models).map(([id, m]) => {
+                    const countStr = counts[id] ?? '0/0';
+                    const [anom, total] = countStr.split('/').map(Number);
+                    const hasAnomaly = anom > 0;
+                    return (
+                      <div key={id} className={`rounded-lg border p-4 ${hasAnomaly ? 'border-red-300 bg-red-50' : 'border-gray-200 bg-gray-50'}`}>
+                        <div className="flex items-center justify-between mb-2">
+                          <span className="font-semibold text-gray-900 text-sm">{m.name}</span>
+                          <span className={`text-lg font-bold font-mono ${hasAnomaly ? 'text-red-700' : 'text-green-700'}`}>{countStr}</span>
+                        </div>
+                        <div className="text-xs text-gray-500 space-y-0.5">
+                          <div>Threshold: <span className="font-mono">{m.threshold?.toFixed(6)}</span></div>
+                          <div>Window: {m.window_duration_seconds}s</div>
+                          <div>Fields: {m.fields?.join(', ')}</div>
+                        </div>
+                        {hasAnomaly && <p className="mt-2 text-xs font-semibold text-red-700">{anom} anomalous window{anom > 1 ? 's' : ''} detected</p>}
+                      </div>
+                    );
+                  })}
+                </div>
+
+                {/* Per-model window scores */}
+                {results.map(result => {
+                  const hasScores = result.scores?.length > 0;
+                  const anomalousWindows = result.scores?.filter(s => s.is_anomaly) ?? [];
+                  return (
+                    <div key={result.model_id}>
+                      <div className="flex items-center gap-2 mb-2">
+                        <h4 className="text-sm font-semibold text-gray-700">{result.model_name}</h4>
+                        <span className="text-xs text-gray-400">threshold: <span className="font-mono">{result.threshold_value?.toFixed(6)}</span></span>
+                        <span className="text-xs text-gray-400">{result.num_anomalies}/{result.num_windows} windows</span>
+                      </div>
+
+                      {hasScores && (
+                        <div className="border border-gray-200 rounded-lg overflow-hidden mb-3">
+                          <table className="w-full text-sm">
+                            <thead className="bg-gray-50 border-b border-gray-200">
+                              <tr>
+                                <th className="px-3 py-2 text-left text-xs font-semibold text-gray-500 uppercase">Window Start</th>
+                                <th className="px-3 py-2 text-right text-xs font-semibold text-gray-500 uppercase">Error</th>
+                                <th className="px-3 py-2 text-center text-xs font-semibold text-gray-500 uppercase">Status</th>
+                              </tr>
+                            </thead>
+                            <tbody className="divide-y divide-gray-100">
+                              {result.scores.map((s, i) => (
+                                <tr key={i} className={s.is_anomaly ? 'bg-red-50' : 'hover:bg-gray-50'}>
+                                  <td className="px-3 py-2 font-mono text-xs text-gray-700">{fmtTs(s.window_start_time)}</td>
+                                  <td className="px-3 py-2 text-right font-mono text-xs text-gray-900">{s.reconstruction_error?.toFixed(6)}</td>
+                                  <td className="px-3 py-2 text-center">
+                                    <span className={`px-2 py-0.5 rounded text-xs font-medium ${s.is_anomaly ? 'bg-red-100 text-red-800' : 'bg-green-100 text-green-800'}`}>
+                                      {s.is_anomaly ? 'ANOMALY' : 'OK'}
+                                    </span>
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      )}
+
+                      {/* SHAP explanations for anomalous windows */}
+                      {anomalousWindows.filter(s => s.explanation).map((s, i) => (
+                        <div key={i} className="mb-4">
+                          <div className="flex items-center gap-2 mb-2">
+                            <span className="text-xs font-semibold text-red-700">Explanation — anomalous window @ {fmtTs(s.window_start_time)}</span>
+                            <span className="px-1.5 py-0.5 text-xs bg-gray-100 text-gray-600 rounded uppercase">{s.explanation.method}</span>
+                          </div>
+                          <p className="text-xs text-gray-500 mb-2">Baseline error: <span className="font-mono">{s.explanation.baseline?.toFixed(6)}</span> · Reconstruction error: <span className="font-mono">{s.reconstruction_error?.toFixed(6)}</span></p>
+                          <FeatureImportanceChart
+                            importances={Object.fromEntries(Object.entries(s.explanation.attributions).map(([k, v]) => [k, { mean: v }]))}
+                            metric="shap"
+                            computedAt={s.explanation.computed_at}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  );
+                })}
+
+                {results.length === 0 && (
+                  <p className="text-sm text-gray-400 text-center py-4">No per-window results returned. Enable explain or check model training.</p>
+                )}
+              </>;
+            })()}
+
           </div>
         </div>
       )}

--- a/src/pages/Analytics.jsx
+++ b/src/pages/Analytics.jsx
@@ -8,14 +8,19 @@ const Analytics = () => {
   const mlUrl = '/' + import.meta.env.VITE_ML_HOST;
   const dataStorageUrl = '/' + import.meta.env.VITE_DATA_STORAGE_HOST;
 
-  const [formData, setFormData] = useState({
-    output_field: '',
-    snssai_sst: '',
-    dnn: '',
-    snssai_sd: '',
-    model_id: null,
-    lookback_seconds: 1800,
+  const STORAGE_KEY = 'aion-analytics-form';
+  const [formData, setFormData] = useState(() => {
+    try {
+      const saved = JSON.parse(sessionStorage.getItem(STORAGE_KEY));
+      if (saved && typeof saved === 'object') return { output_field: '', snssai_sst: '', dnn: '', snssai_sd: '', model_id: null, lookback_seconds: 1800, ...saved };
+    } catch {}
+    return { output_field: '', snssai_sst: '', dnn: '', snssai_sd: '', model_id: null, lookback_seconds: 1800 };
   });
+
+  // Persist form state across navigation
+  useEffect(() => {
+    try { sessionStorage.setItem(STORAGE_KEY, JSON.stringify(formData)); } catch {}
+  }, [formData]);
 
   const [prediction, setPrediction] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -140,13 +145,13 @@ const Analytics = () => {
 
   return (
     <div className="space-y-6">
-      <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
-        <h2 className="text-2xl font-bold text-gray-900 mb-1">Analytics Predictions</h2>
+      <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-gray-900 mb-1">Analytics Predictions</h2>
         <p className="text-sm text-gray-500">Run forecast or anomaly detection on network data</p>
       </div>
 
       {/* Form */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+      <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
         <h3 className="text-lg font-semibold text-gray-900 mb-4">Request Parameters</h3>
         <form onSubmit={fetchPrediction} className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -265,7 +270,7 @@ const Analytics = () => {
 
       {/* Results */}
       {prediction && (
-        <div className="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
           <div className="px-6 py-4 border-b border-gray-200 bg-gradient-to-r from-green-50 to-blue-50">
             <h3 className="text-lg font-semibold text-gray-900">{isAnomaly ? 'Anomaly Detection Results' : 'Prediction Results'}</h3>
             <p className="text-sm text-gray-500">

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,205 +1,205 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import ServiceStatusOverview from '../components/ServiceStatusOverview';
-import DataTable from '../components/DataTable';
 import ProducerManager from '../components/ProducerManager';
 import { useWebSocket } from '../hooks/useWebSocket';
 
+const SUMMARY_COLS = ['timestamp', 'event', 'snssai_sst', 'snssai_sd', 'dnn'];
+
+const humanize = (s) => String(s).replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+
+const renderValue = (value) => {
+  if (value == null || value === '') return '-';
+  if (Array.isArray(value)) return `[${value.length} items]`;
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+};
+
+// Parse "key=value key2=value2" filter string
+const parseFilter = (str) => {
+  const filters = {};
+  for (const part of str.trim().split(/\s+/)) {
+    const eq = part.indexOf('=');
+    if (eq > 0) filters[part.slice(0, eq)] = part.slice(eq + 1);
+  }
+  return filters;
+};
+
+const matchesFilter = (row, filters) => {
+  for (const [k, v] of Object.entries(filters)) {
+    if (String(row[k] ?? '').toLowerCase() !== v.toLowerCase()) return false;
+  }
+  return true;
+};
+
 const Dashboard = () => {
-  //const rawDataUrl = import.meta.env.VITE_RAW_DATA_URL;
   const rawDataUrl = '/data-ingestion';
   const wsBase = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/data-ingestion/ws/ingestion`;
 
-  // State for real-time data
   const [realtimeData, setRealtimeData] = useState([]);
   const [wsConnected, setWsConnected] = useState(false);
   const [producers, setProducers] = useState([]);
   const [selectedSubscription, setSelectedSubscription] = useState('');
+  const [selectedRow, setSelectedRow] = useState(null);
+  const [filterStr, setFilterStr] = useState('');
 
-  // WebSocket connection for data ingestion - connect per selected subscription
   const wsUrl = selectedSubscription ? `${wsBase}/${selectedSubscription}` : null;
   const { disconnect: wsDisconnect } = useWebSocket(wsUrl, {
     enabled: Boolean(wsUrl),
     onMessage: (message) => {
       if (message.type === 'data_ingested' && message.data) {
-        setRealtimeData(prev => [message.data, ...prev].slice(0, 100)); // Keep last 100 entries
+        const { metrics, tags, ...rest } = message.data;
+        const flat = { ...rest, ...(tags || {}), ...(metrics || {}) };
+        setRealtimeData(prev => [flat, ...prev].slice(0, 100));
       }
     },
     onOpen: () => setWsConnected(true),
     onClose: () => setWsConnected(false),
-    onError: (error) => {
-      console.error('WebSocket error:', error);
-      setWsConnected(false);
-    }
+    onError: () => setWsConnected(false),
   });
 
-  // Clear realtime data whenever the selected subscription changes (or is cleared)
   useEffect(() => {
     setRealtimeData([]);
+    setSelectedRow(null);
     if (!selectedSubscription) {
       setWsConnected(false);
       if (wsDisconnect) wsDisconnect();
     }
   }, [selectedSubscription]);
 
-  // Fetch available subscriptions so the user can select one for the WS
   useEffect(() => {
     const fetchSubscriptions = async () => {
       try {
-        const res = await fetch(`${rawDataUrl}/subscriptions`);
+        const res = await fetch(`${rawDataUrl}/nef/subscriptions`);
         if (!res.ok) return;
         const data = await res.json();
-        const list = Array.isArray(data.producers) ? data.producers : [];
-        const parsed = list
-          .map((item) => {
-            const entries = Object.entries(item || {});
-            if (entries.length === 0) return null;
-            const [id, info] = entries[0];
-            // Handle both old format (url string) and new format (object with url, label)
-            if (typeof info === 'string') {
-              return { id, url: info, label: id };
-            }
-            return { id, url: info.url || '', label: info.label || id };
-          })
-          .filter(Boolean);
-        setProducers(parsed);
-
-        // Auto-select first producer if none selected
-        if (!selectedSubscription && parsed.length > 0) {
-          setSelectedSubscription(parsed[0].id);
-        }
-
-        // If the currently selected subscription was removed on the backend,
-        // clear the selection (this will trigger the effect above to clear data)
-        if (selectedSubscription && !parsed.find((p) => p.id === selectedSubscription)) {
-          setSelectedSubscription('');
-        }
+        const list = Array.isArray(data.subscriptions) ? data.subscriptions : [];
+        setProducers(list.map(sub => ({ id: sub.notif_id, label: sub.notif_id, url: sub.nef_url || '' })));
       } catch (err) {
         console.error('Failed to fetch subscriptions', err);
       }
     };
-
     fetchSubscriptions();
     const id = setInterval(fetchSubscriptions, 5000);
     return () => clearInterval(id);
-  }, [rawDataUrl, selectedSubscription]);
+  }, [rawDataUrl]);
 
-  // Helper to convert snake_case keys to human headers
-  const humanize = (s) => {
-    if (!s) return '';
-    return String(s).replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-  };
+  const filters = useMemo(() => parseFilter(filterStr), [filterStr]);
+  const filteredData = useMemo(
+    () => realtimeData.filter(row => matchesFilter(row, filters)),
+    [realtimeData, filters]
+  );
 
-  // Fallback columns used until we have realtime data
-  const defaultRawDataColumns = [
-    { header: 'Timestamp', accessor: 'timestamp' },
-    { header: 'Payload', accessor: 'payload' },
-  ];
-
-  // Safe getter that supports simple dot notation for nested values
-  const getValue = (obj, key) => {
-    if (!obj || !key) return undefined;
-    if (!key.includes('.')) return obj[key];
-    return key.split('.').reduce((o, k) => (o && k in o ? o[k] : undefined), obj);
-  };
-
-  const rawDataColumns = useMemo(() => {
-    if (!Array.isArray(realtimeData) || realtimeData.length === 0) {
-      return defaultRawDataColumns;
-    }
-
-    const sample = realtimeData[0];
-    // Ensure deterministic ordering: timestamp first if present, then rest alphabetically
-    const keys = Object.keys(sample);
-    keys.sort((a, b) => {
-      if (a === 'timestamp') return -1;
-      if (b === 'timestamp') return 1;
-      return a.localeCompare(b);
-    });
-
-    return keys.map((key) => {
-      const col = { accessor: key, header: humanize(key) };
-
-      // default: show value or '-' for null/undefined
-      col.render = (value) => (value == null || value === '' ? '-' : String(value));
-
-      return col;
-    });
-  }, [realtimeData]);
+  const detailKeys = selectedRow ? Object.keys(selectedRow).filter(k => !SUMMARY_COLS.includes(k)) : [];
 
   return (
     <div className="space-y-8">
-
-      {/* Producers management */}
       <ProducerManager apiBase={rawDataUrl} onRemove={(id) => {
-        // If the removed producer was the active subscription, clear selection
-        // (the effect will handle clearing data and disconnecting WS)
-        if (id === selectedSubscription) {
-          setSelectedSubscription('');
-        }
+        if (id === selectedSubscription) setSelectedSubscription('');
       }} />
 
-      {/* Real-time Data Section */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
-          <h2 className="text-xl font-bold text-gray-900">Ingestion Data</h2>
-          <div className="flex items-center gap-2 w-full sm:w-auto">
-            {producers.length > 0 ? (
-              <>
-                <label className="text-sm font-medium text-gray-700 shrink-0">Active Producer:</label>
-                <select
-                  value={selectedSubscription}
-                  onChange={(e) => setSelectedSubscription(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                >
-                  {producers.map((p) => (
-                    <option key={p.id} value={p.id}>{p.label} - {p.url}</option>
-                  ))}
-                </select>
-              </>
-            ) : (
-              <span className="text-sm text-gray-400">No producers available</span>
-            )}
+      <div className="bg-white rounded-lg border border-gray-200 shadow-sm">
+        {/* Header bar */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-6 border-b border-gray-200">
+          <div className="flex items-center gap-3">
+            <h2 className="text-xl font-bold text-gray-900">Ingestion Data</h2>
+            <span className={`w-2 h-2 rounded-full ${wsConnected ? 'bg-green-400' : 'bg-gray-300'}`} title={wsConnected ? 'Connected' : 'Disconnected'} />
+          </div>
+          <div className="flex items-center gap-3 w-full sm:w-auto">
+            {/* Subscription selector */}
+            <select
+              value={selectedSubscription}
+              onChange={(e) => setSelectedSubscription(e.target.value)}
+              className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">— select subscription —</option>
+              {producers.map(p => (
+                <option key={p.id} value={p.id}>{p.label}</option>
+              ))}
+            </select>
+            {/* Filter input */}
+            <input
+              type="text"
+              placeholder="snssai_sst=1 event=PERF_DATA"
+              value={filterStr}
+              onChange={e => setFilterStr(e.target.value)}
+              className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 w-64 font-mono"
+            />
           </div>
         </div>
 
-        {realtimeData.length > 0 ? (
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
-                <tr>
-                  {rawDataColumns.map((col) => (
-                    <th
-                      key={col.accessor}
-                      className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap"
-                    >
-                      {col.header}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
-                {realtimeData.map((row, idx) => (
-                  <tr
-                    key={idx}
-                    className={`hover:bg-gray-50 transition-colors ${idx === 0 ? 'bg-blue-50' : ''}`}
-                  >
-                    {rawDataColumns.map((col) => (
-                      <td key={col.accessor} className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
-                        {col.render ? col.render(getValue(row, col.accessor)) : (getValue(row, col.accessor) ?? '-')}
-                      </td>
+        {/* Two-column body */}
+        <div className="flex divide-x divide-gray-200" style={{ minHeight: '320px' }}>
+          {/* Left: summary table */}
+          <div className="flex-1 overflow-auto">
+            {filteredData.length > 0 ? (
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50 sticky top-0">
+                  <tr>
+                    {SUMMARY_COLS.map(col => (
+                      <th key={col} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+                        {humanize(col)}
+                      </th>
                     ))}
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-100">
+                  {filteredData.map((row, idx) => {
+                    const isSelected = selectedRow === row;
+                    return (
+                      <tr
+                        key={idx}
+                        onClick={() => setSelectedRow(isSelected ? null : row)}
+                        className={`cursor-pointer transition-colors ${isSelected ? 'bg-blue-100 hover:bg-blue-100' : 'hover:bg-gray-50'}`}
+                      >
+                        {SUMMARY_COLS.map(col => (
+                          <td key={col} className="px-4 py-2.5 text-sm text-gray-900 whitespace-nowrap">
+                            {col === 'timestamp' && row[col]
+                              ? new Date(row[col] * 1000).toLocaleTimeString()
+                              : (row[col] ?? <span className="text-gray-300">—</span>)}
+                          </td>
+                        ))}
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            ) : (
+              <div className="flex items-center justify-center h-full py-16 text-sm text-gray-400">
+                {!selectedSubscription
+                  ? 'Select a subscription to start streaming'
+                  : wsConnected
+                  ? filterStr ? 'No rows match filter' : 'Waiting for data...'
+                  : 'Connecting...'}
+              </div>
+            )}
           </div>
-        ) : (
-          <div className="text-center py-12">
-            <p className="text-gray-500">
-              {wsConnected ? 'Waiting for data...' : 'Connecting to data stream...'}
-            </p>
+
+          {/* Right: detail panel */}
+          <div className="w-80 shrink-0 overflow-auto p-5">
+            {selectedRow ? (
+              <>
+                <div className="flex items-center justify-between mb-4">
+                  <h3 className="text-sm font-semibold text-gray-700">Row Details</h3>
+                  <button onClick={() => setSelectedRow(null)} className="text-gray-400 hover:text-gray-600 text-xs">✕ close</button>
+                </div>
+                <div className="space-y-3">
+                  {detailKeys.map(k => (
+                    <div key={k}>
+                      <p className="text-xs font-medium text-gray-400 uppercase">{humanize(k)}</p>
+                      <p className="text-sm text-gray-900 font-mono break-all">{renderValue(selectedRow[k])}</p>
+                    </div>
+                  ))}
+                  {detailKeys.length === 0 && (
+                    <p className="text-sm text-gray-400">No extra fields.</p>
+                  )}
+                </div>
+              </>
+            ) : (
+              <div className="flex items-center justify-center h-full text-sm text-gray-300">
+                Click a row to see details
+              </div>
+            )}
           </div>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -91,37 +91,38 @@ const Dashboard = () => {
   const detailKeys = selectedRow ? Object.keys(selectedRow).filter(k => !SUMMARY_COLS.includes(k)) : [];
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       <ProducerManager apiBase={rawDataUrl} onRemove={(id) => {
         if (id === selectedSubscription) setSelectedSubscription('');
       }} />
 
-      <div className="bg-white rounded-lg border border-gray-200 shadow-sm">
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
         {/* Header bar */}
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-6 border-b border-gray-200">
-          <div className="flex items-center gap-3">
-            <h2 className="text-xl font-bold text-gray-900">Ingestion Data</h2>
-            <span className={`w-2 h-2 rounded-full ${wsConnected ? 'bg-green-400' : 'bg-gray-300'}`} title={wsConnected ? 'Connected' : 'Disconnected'} />
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-5 py-4 border-b border-gray-200">
+          <div className="flex items-center gap-2.5">
+            <h2 className="text-base font-semibold text-gray-900">Ingestion Data</h2>
+            <span
+              className={`w-2 h-2 rounded-full shrink-0 ${wsConnected ? 'bg-green-400' : 'bg-gray-300'}`}
+              title={wsConnected ? 'Connected' : 'Disconnected'}
+            />
           </div>
-          <div className="flex items-center gap-3 w-full sm:w-auto">
-            {/* Subscription selector */}
+          <div className="flex flex-wrap items-center gap-2 w-full sm:w-auto">
             <select
               value={selectedSubscription}
               onChange={(e) => setSelectedSubscription(e.target.value)}
-              className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+              className="px-3 py-1.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none"
             >
               <option value="">— select subscription —</option>
               {producers.map(p => (
                 <option key={p.id} value={p.id}>{p.label}</option>
               ))}
             </select>
-            {/* Filter input */}
             <input
               type="text"
               placeholder="snssai_sst=1 event=PERF_DATA"
               value={filterStr}
               onChange={e => setFilterStr(e.target.value)}
-              className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 w-64 font-mono"
+              className="px-3 py-1.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none w-56 font-mono"
             />
           </div>
         </div>
@@ -132,10 +133,10 @@ const Dashboard = () => {
           <div className="flex-1 overflow-auto">
             {filteredData.length > 0 ? (
               <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50 sticky top-0">
+                <thead className="bg-gray-50 sticky top-0 z-10">
                   <tr>
                     {SUMMARY_COLS.map(col => (
-                      <th key={col} className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+                      <th key={col} className="px-4 py-2.5 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider whitespace-nowrap">
                         {humanize(col)}
                       </th>
                     ))}
@@ -151,7 +152,7 @@ const Dashboard = () => {
                         className={`cursor-pointer transition-colors ${isSelected ? 'bg-blue-100 hover:bg-blue-100' : 'hover:bg-gray-50'}`}
                       >
                         {SUMMARY_COLS.map(col => (
-                          <td key={col} className="px-4 py-2.5 text-sm text-gray-900 whitespace-nowrap">
+                          <td key={col} className="px-4 py-2 text-sm text-gray-900 whitespace-nowrap font-mono">
                             {col === 'timestamp' && row[col]
                               ? new Date(row[col] * 1000).toLocaleTimeString()
                               : (row[col] ?? <span className="text-gray-300">—</span>)}
@@ -167,25 +168,25 @@ const Dashboard = () => {
                 {!selectedSubscription
                   ? 'Select a subscription to start streaming'
                   : wsConnected
-                  ? filterStr ? 'No rows match filter' : 'Waiting for data...'
-                  : 'Connecting...'}
+                  ? filterStr ? 'No rows match filter' : 'Waiting for data…'
+                  : 'Connecting…'}
               </div>
             )}
           </div>
 
           {/* Right: detail panel */}
-          <div className="w-80 shrink-0 overflow-auto p-5">
+          <div className="w-72 shrink-0 overflow-auto p-4 bg-gray-50">
             {selectedRow ? (
               <>
-                <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-sm font-semibold text-gray-700">Row Details</h3>
-                  <button onClick={() => setSelectedRow(null)} className="text-gray-400 hover:text-gray-600 text-xs">✕ close</button>
+                <div className="flex items-center justify-between mb-3">
+                  <h3 className="text-xs font-semibold text-gray-600 uppercase tracking-wide">Row Details</h3>
+                  <button onClick={() => setSelectedRow(null)} className="text-gray-400 hover:text-gray-600 text-xs transition-colors">✕</button>
                 </div>
-                <div className="space-y-3">
+                <div className="space-y-2.5">
                   {detailKeys.map(k => (
                     <div key={k}>
-                      <p className="text-xs font-medium text-gray-400 uppercase">{humanize(k)}</p>
-                      <p className="text-sm text-gray-900 font-mono break-all">{renderValue(selectedRow[k])}</p>
+                      <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">{humanize(k)}</p>
+                      <p className="text-sm text-gray-900 font-mono break-all leading-snug">{renderValue(selectedRow[k])}</p>
                     </div>
                   ))}
                   {detailKeys.length === 0 && (
@@ -194,7 +195,7 @@ const Dashboard = () => {
                 </div>
               </>
             ) : (
-              <div className="flex items-center justify-center h-full text-sm text-gray-300">
+              <div className="flex items-center justify-center h-full text-xs text-gray-400">
                 Click a row to see details
               </div>
             )}

--- a/src/pages/MLModels.jsx
+++ b/src/pages/MLModels.jsx
@@ -235,18 +235,29 @@ const PolicyStatusBadge = ({ modelName, policyUrl }) => {
 // ModelCard
 const ModelCard = memo(({ model, onShowDetails, onTrain, onSetDefault, onDelete, isTraining, copiedId, onCopyId, isNew, policyUrl }) => {
   const isBestForAny = model.best_for_fields?.length > 0;
+  const isTrained = model.latest_version != null;
+  const eventColor = EVENT_COLORS[model.event_type] || 'bg-gray-100 text-gray-700';
+
   return (
-    <div className={`bg-white rounded-lg border p-6 shadow-sm hover:shadow-md transition-shadow [container-type:inline-size] ${isNew ? 'border-green-500 ring-2 ring-green-200' : 'border-gray-200'}`}>
-      {/* Header: name+badges left, buttons right - stacks when card is narrow (large font sizes) */}
+    <div className={`bg-white rounded-lg border p-5 shadow-sm hover:shadow-md transition-shadow [container-type:inline-size] ${isNew ? 'border-green-500 ring-2 ring-green-200' : 'border-gray-200'}`}>
+      {/* Header */}
       <div className="flex flex-wrap items-start gap-3 mb-3">
         <div className="flex-1 min-w-0">
-          <h3 className="text-lg font-semibold text-gray-900 break-words">{model.name || 'Unnamed Model'}</h3>
-          <div className="flex items-center gap-2 mt-2 flex-wrap">
-            <span className="px-2 py-0.5 text-xs font-bold font-mono bg-gray-200 text-gray-800 rounded">
-              v{model.latest_version ?? 'N/A'}
+          <div className="flex items-center gap-2 mb-1">
+            <span className={`w-2 h-2 rounded-full shrink-0 ${isTrained ? 'bg-green-400' : 'bg-gray-300'}`} title={isTrained ? `Trained (v${model.latest_version})` : 'Not trained'} />
+            <h3 className="text-base font-semibold text-gray-900 break-words leading-tight">{model.name || 'Unnamed Model'}</h3>
+          </div>
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className={`px-2 py-0.5 text-xs font-bold font-mono rounded ${isTrained ? 'bg-green-100 text-green-800' : 'bg-gray-200 text-gray-600'}`}>
+              {isTrained ? `v${model.latest_version}` : 'untrained'}
             </span>
+            {model.event_type && (
+              <span className={`px-2 py-0.5 text-xs font-bold rounded uppercase tracking-wide ${eventColor}`}>
+                {model.event_type}
+              </span>
+            )}
             {model.architecture && (
-              <span className="px-2 py-0.5 text-xs font-bold bg-purple-200 text-purple-900 rounded uppercase tracking-wide">
+              <span className="px-2 py-0.5 text-xs font-semibold bg-purple-100 text-purple-800 rounded uppercase tracking-wide">
                 {model.architecture}
               </span>
             )}
@@ -257,13 +268,15 @@ const ModelCard = memo(({ model, onShowDetails, onTrain, onSetDefault, onDelete,
             )}
             <PolicyStatusBadge modelName={model.name} policyUrl={policyUrl} />
           </div>
-          <div className="flex flex-wrap gap-1 mt-2 min-h-[22px]">
-            {isBestForAny && model.best_for_fields.map(field => (
-              <span key={field} className="px-2 py-0.5 text-xs font-bold bg-green-200 text-green-900 rounded-full">
-                Best for: {field}
-              </span>
-            ))}
-          </div>
+          {isBestForAny && (
+            <div className="flex flex-wrap gap-1 mt-2">
+              {model.best_for_fields.map(field => (
+                <span key={field} className="px-2 py-0.5 text-xs font-bold bg-green-200 text-green-900 rounded-full">
+                  ★ {field}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
 
         <div className="model-card-actions shrink-0 flex flex-col gap-2">
@@ -317,42 +330,44 @@ const ModelCard = memo(({ model, onShowDetails, onTrain, onSetDefault, onDelete,
         {/* /flex-wrap header */}
       </div>
 
-      <hr className="border-gray-200 mt-1 mb-3" />
-      <div className="space-y-2 text-sm">
-        {model.created_at && (
+      <hr className="border-gray-100 mt-3 mb-3" />
+      <div className="space-y-1.5 text-sm">
+        {model.training_loss != null && (
           <div className="flex justify-between">
-            <span className="text-gray-600">Created at:</span>
-            <span className="font-medium text-gray-900">
-              {new Date(model.created_at).toLocaleDateString()}
-            </span>
+            <span className="text-gray-500">Training loss:</span>
+            <span className="font-mono text-gray-900 text-xs">{Number(model.training_loss).toFixed(6)}</span>
           </div>
         )}
         {model.last_trained_at && (
           <div className="flex justify-between">
-            <span className='text-gray-600'>Last trained at:</span>
-            <span className="font-medium text-gray-900">
-              {new Date(model.last_trained_at).toLocaleString()}
-            </span>
+            <span className="text-gray-500">Last trained:</span>
+            <span className="text-gray-900 text-xs">{new Date(model.last_trained_at).toLocaleString()}</span>
+          </div>
+        )}
+        {model.created_at && (
+          <div className="flex justify-between">
+            <span className="text-gray-500">Created:</span>
+            <span className="text-gray-900 text-xs">{new Date(model.created_at).toLocaleDateString()}</span>
           </div>
         )}
         {model.id && (
           <div className="flex justify-between items-center">
-            <span className='text-gray-600'>ID:</span>
-            <div className="flex items-center gap-2 ml-2 min-w-0">
-              <span className="font-medium text-gray-900 truncate font-mono text-xs" title={model.id}>
-                {model.id}
+            <span className="text-gray-500">ID:</span>
+            <div className="flex items-center gap-1 min-w-0">
+              <span className="text-gray-700 truncate font-mono text-xs" title={model.id}>
+                {model.id.slice(0, 8)}…
               </span>
               <button
                 onClick={() => onCopyId(model.id, model.id)}
                 className="p-1 hover:bg-gray-200 rounded transition-colors shrink-0"
-                title="Copy model ID"
+                title="Copy full ID"
               >
                 {copiedId === model.id ? (
-                  <svg className="w-3.5 h-3.5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-3 h-3 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
                 ) : (
-                  <svg className="w-3.5 h-3.5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
                   </svg>
                 )}
@@ -364,18 +379,19 @@ const ModelCard = memo(({ model, onShowDetails, onTrain, onSetDefault, onDelete,
     </div>
   );
 }, (prevProps, nextProps) => {
-  const modelSame = prevProps.model.id === nextProps.model.id &&
+  const modelSame =
+    prevProps.model.id === nextProps.model.id &&
     prevProps.model.created_at === nextProps.model.created_at &&
     prevProps.model.latest_version === nextProps.model.latest_version &&
     prevProps.model.architecture === nextProps.model.architecture &&
+    prevProps.model.event_type === nextProps.model.event_type &&
+    prevProps.model.training_loss === nextProps.model.training_loss &&
     JSON.stringify(prevProps.model.best_for_fields) === JSON.stringify(nextProps.model.best_for_fields);
-  const isTrainingSame = prevProps.isTraining === nextProps.isTraining;
-  const copiedIdSame = prevProps.copiedId === nextProps.copiedId;
-  return modelSame && isTrainingSame && copiedIdSame;
+  return modelSame && prevProps.isTraining === nextProps.isTraining && prevProps.copiedId === nextProps.copiedId;
 });
 
 // CreateModelModal
-const FieldCheckboxes = ({ fieldKey, label, fields, loadingFields, selected, onToggle }) => {
+const FieldCheckboxes = ({ fieldKey, label, fields, loadingFields, selected, onToggle, fieldEventMap = {}, activeEvents = new Set() }) => {
   const [filter, setFilter] = useState('');
   const [recentItems, setRecentItems] = useState([]);
   const storageKey = `recent-search-ml-${fieldKey}`;
@@ -408,7 +424,11 @@ const FieldCheckboxes = ({ fieldKey, label, fields, loadingFields, selected, onT
     }
   };
 
-  const visible = fields.filter(f => f.toLowerCase().includes(filter.toLowerCase()));
+  // Filter by text, then by active events (only show compatible fields)
+  const eventCompatible = activeEvents.size > 0
+    ? fields.filter(f => selected.includes(f) || (fieldEventMap[f] || []).some(e => activeEvents.has(e)))
+    : fields;
+  const visible = eventCompatible.filter(f => f.toLowerCase().includes(filter.toLowerCase()));
   const unselected = visible.filter(f => !selected.includes(f));
 
   // Recent items that are valid and not currently selected
@@ -426,19 +446,25 @@ const FieldCheckboxes = ({ fieldKey, label, fields, loadingFields, selected, onT
           {/* Selected chips */}
           {selected.length > 0 && (
             <div className="flex flex-wrap gap-1 p-2 border-b border-gray-200">
-              {selected.map(f => (
-                <button
-                  key={f}
-                  type="button"
-                  onClick={() => handleToggle(f)}
-                  className="flex items-center gap-1 px-2 py-0.5 bg-blue-100 text-blue-800 text-xs rounded-full hover:bg-blue-200 transition-colors"
-                >
-                  {f}
-                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              ))}
+              {selected.map(f => {
+                const events = fieldEventMap[f] || [];
+                return (
+                  <button
+                    key={f}
+                    type="button"
+                    onClick={() => handleToggle(f)}
+                    className="flex items-center gap-1 px-2 py-0.5 bg-blue-100 text-blue-800 text-xs rounded-full hover:bg-blue-200 transition-colors"
+                  >
+                    {events.length > 0 && (
+                      <span className="text-blue-400 font-normal">{events[0]}/</span>
+                    )}
+                    {f}
+                    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                );
+              })}
             </div>
           )}
           {/* Recent fields - shown when filter is empty and there are recent items */}
@@ -500,7 +526,22 @@ const FieldCheckboxes = ({ fieldKey, label, fields, loadingFields, selected, onT
   );
 };
 
-const CreateModelModal = memo(({ showCreateModal, setShowCreateModal, handleCreateModel, mlUrl }) => {
+const EVENT_COLORS = {
+  PERF_DATA:   'bg-blue-100 text-blue-800',
+  UE_MOBILITY: 'bg-purple-100 text-purple-800',
+  UE_COMM:     'bg-green-100 text-green-800',
+};
+
+const intersectSets = (sets) => {
+  if (sets.length === 0) return new Set();
+  let result = new Set(sets[0]);
+  for (let i = 1; i < sets.length; i++) {
+    result = new Set([...result].filter(x => sets[i].includes(x)));
+  }
+  return result;
+};
+
+const CreateModelModal = memo(({ showCreateModal, setShowCreateModal, handleCreateModel, mlUrl, dataStorageUrl }) => {
   const [formData, setFormData] = useState({
     name: '',
     architecture: 'ann',
@@ -514,13 +555,12 @@ const CreateModelModal = memo(({ showCreateModal, setShowCreateModal, handleCrea
   const [isCreating, setIsCreating] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [hiddenSize, setHiddenSize] = useState(32);
-  const [fields, setFields] = useState([]);
+  const [fieldEventMap, setFieldEventMap] = useState({});  // {field: [events]}
   const [loadingFields, setLoadingFields] = useState(true);
   const [isAnomaly, setIsAnomaly] = useState(false);
 
   useEffect(() => {
     if (!showCreateModal) {
-      // Reset form when modal closes
       setIsAnomaly(false);
       setFormData({
         name: '',
@@ -538,17 +578,25 @@ const CreateModelModal = memo(({ showCreateModal, setShowCreateModal, handleCrea
     const fetchFields = async () => {
       setLoadingFields(true);
       try {
-        const response = await fetch(`${mlUrl}/v1/fields`);
+        const response = await fetch(`${dataStorageUrl}/api/v1/processed/fields`);
         if (response.ok) {
           const data = await response.json();
-          setFields((data.fields ?? []).map(f => (typeof f === 'object' ? f.name : f)));
+          setFieldEventMap(typeof data === 'object' && !Array.isArray(data) ? data : {});
         }
       } finally {
         setLoadingFields(false);
       }
     };
     fetchFields();
-  }, [showCreateModal, mlUrl]);
+  }, [showCreateModal, dataStorageUrl]);
+
+  const allFields = Object.keys(fieldEventMap).sort();
+
+  // Derive active events from all selected fields (intersection)
+  const allSelected = [...formData.input_fields, ...formData.output_fields];
+  const activeEvents = allSelected.length > 0
+    ? intersectSets(allSelected.map(f => fieldEventMap[f] || []))
+    : new Set();
 
   if (!showCreateModal) return null;
 
@@ -650,12 +698,25 @@ const CreateModelModal = memo(({ showCreateModal, setShowCreateModal, handleCrea
             </div>
           )}
 
+          {/* Event preview */}
+          {allSelected.length > 0 && (
+            <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-gray-50 border border-gray-200">
+              <span className="text-xs font-medium text-gray-500">Event:</span>
+              {activeEvents.size > 0
+                ? [...activeEvents].map(e => (
+                    <span key={e} className={`px-2 py-0.5 text-xs font-semibold rounded-full ${EVENT_COLORS[e] || 'bg-gray-100 text-gray-700'}`}>{e}</span>
+                  ))
+                : <span className="text-xs text-red-600 font-medium">No common event — fields incompatible</span>
+              }
+            </div>
+          )}
+
           {/* Input Fields */}
-          <FieldCheckboxes fieldKey="input_fields" label="Input Fields" fields={fields} loadingFields={loadingFields} selected={formData.input_fields} onToggle={toggleField} />
+          <FieldCheckboxes fieldKey="input_fields" label="Input Fields" fields={allFields} loadingFields={loadingFields} selected={formData.input_fields} onToggle={toggleField} fieldEventMap={fieldEventMap} activeEvents={activeEvents} />
 
           {/* Output Fields - Hidden for anomaly */}
           {!isAnomaly && (
-            <FieldCheckboxes fieldKey="output_fields" label="Output Fields" fields={fields} loadingFields={loadingFields} selected={formData.output_fields} onToggle={toggleField} />
+            <FieldCheckboxes fieldKey="output_fields" label="Output Fields" fields={allFields} loadingFields={loadingFields} selected={formData.output_fields} onToggle={toggleField} fieldEventMap={fieldEventMap} activeEvents={activeEvents} />
           )}
 
           {/* Steps grid */}
@@ -892,6 +953,7 @@ const AllJobsModal = ({ showModal, setShowModal, mlUrl, onJobsUpdate }) => {
     if (status === 'completed') return `${base} bg-green-100 text-green-800`;
     if (status === 'failed') return `${base} bg-red-100 text-red-800`;
     if (status === 'running') return `${base} bg-yellow-100 text-yellow-800`;
+    if (status === 'pending') return `${base} bg-blue-100 text-blue-800`;
     return `${base} bg-gray-100 text-gray-700`;
   };
 
@@ -1088,6 +1150,7 @@ const TrainingModal = ({ model, mlUrl, onClose, onStartTraining, isTraining }) =
     if (status === 'completed') return `${base} bg-green-100 text-green-800`;
     if (status === 'failed') return `${base} bg-red-100 text-red-800`;
     if (status === 'running') return `${base} bg-yellow-100 text-yellow-800`;
+    if (status === 'pending') return `${base} bg-blue-100 text-blue-800`;
     return `${base} bg-gray-100 text-gray-700`;
   };
 
@@ -1162,12 +1225,18 @@ const TrainingModal = ({ model, mlUrl, onClose, onStartTraining, isTraining }) =
           <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 space-y-3">
             <h4 className="text-sm font-semibold text-gray-900">Start New Training Run</h4>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Lookback window (seconds)</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Lookback window (seconds) <span className="text-gray-400 font-normal text-xs">max 30 days = 2592000</span>
+              </label>
               <input
                 type="number"
                 min="1"
+                max="2592000"
                 value={lookbackSeconds}
-                onChange={(e) => setLookbackSeconds(parseInt(e.target.value))}
+                onChange={(e) => {
+                  const v = parseInt(e.target.value);
+                  if (!isNaN(v)) setLookbackSeconds(Math.min(Math.max(1, v), 2592000));
+                }}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm"
               />
             </div>
@@ -1333,27 +1402,50 @@ const ModelDetailsModal = memo(({ showModal, setShowModal, selectedModel, loadin
 
         <div className="p-6 space-y-6 overflow-y-auto flex-1">
           {/* Basic Info */}
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-            <h4 className="text-sm font-semibold text-blue-900 mb-3">Basic Information</h4>
-            <div className="grid grid-cols-2 gap-3 text-sm">
-              <div>
-                <span className="text-gray-600">ID:</span>
-                <span className="ml-2 font-mono text-xs text-gray-900 break-all">{modelDetails.id}</span>
-              </div>
-              <div>
-                <span className="text-gray-600">Architecture:</span>
-                <span className="ml-2 font-medium text-gray-900 uppercase">{modelDetails.architecture ?? config.architecture ?? 'N/A'}</span>
-              </div>
-              <div>
-                <span className="text-gray-600">Version:</span>
-                <span className="ml-2 font-medium text-gray-900">v{modelDetails.latest_version ?? 'N/A'}</span>
-              </div>
-              <div>
-                <span className="text-gray-600">Created:</span>
-                <span className="ml-2 font-medium text-gray-900">
-                  {modelDetails.created_at ? new Date(modelDetails.created_at).toLocaleString() : 'N/A'}
+          <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+            <div className="flex items-center gap-2 mb-3">
+              <h4 className="text-sm font-semibold text-gray-800">Basic Information</h4>
+              {modelDetails.event_type && (
+                <span className={`px-2 py-0.5 text-xs font-bold rounded uppercase tracking-wide ${EVENT_COLORS[modelDetails.event_type] || 'bg-gray-100 text-gray-700'}`}>
+                  {modelDetails.event_type}
                 </span>
+              )}
+              {(modelDetails.architecture ?? config.architecture) && (
+                <span className="px-2 py-0.5 text-xs font-semibold bg-purple-100 text-purple-800 rounded uppercase">
+                  {modelDetails.architecture ?? config.architecture}
+                </span>
+              )}
+              <span className={`px-2 py-0.5 text-xs font-bold rounded ${modelDetails.latest_version != null ? 'bg-green-100 text-green-800' : 'bg-gray-200 text-gray-600'}`}>
+                {modelDetails.latest_version != null ? `v${modelDetails.latest_version}` : 'untrained'}
+              </span>
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <div className="col-span-2">
+                <span className="text-gray-500 text-xs">ID</span>
+                <p className="font-mono text-xs text-gray-900 break-all">{modelDetails.id}</p>
               </div>
+              <div>
+                <span className="text-gray-500 text-xs">Created</span>
+                <p className="text-gray-900 text-xs">{modelDetails.created_at ? new Date(modelDetails.created_at).toLocaleString() : 'N/A'}</p>
+              </div>
+              {modelDetails.last_trained_at && (
+                <div>
+                  <span className="text-gray-500 text-xs">Last trained</span>
+                  <p className="text-gray-900 text-xs">{new Date(modelDetails.last_trained_at).toLocaleString()}</p>
+                </div>
+              )}
+              {modelDetails.training_loss != null && (
+                <div>
+                  <span className="text-gray-500 text-xs">Training loss</span>
+                  <p className="font-mono text-gray-900 text-xs">{Number(modelDetails.training_loss).toFixed(6)}</p>
+                </div>
+              )}
+              {modelDetails.mlflow_run_id && (
+                <div>
+                  <span className="text-gray-500 text-xs">MLflow Run</span>
+                  <p className="font-mono text-xs text-blue-700 truncate" title={modelDetails.mlflow_run_id}>{modelDetails.mlflow_run_id.slice(0, 12)}…</p>
+                </div>
+              )}
             </div>
           </div>
 
@@ -1512,6 +1604,7 @@ const MLModels = () => {
 
   // Field filter
   const [filterField, setFilterField] = useState('');
+  const [filterEvent, setFilterEvent] = useState('');
   const [fields, setFields] = useState([]);
   const [loadingFields, setLoadingFields] = useState(true);
   const [recentFields, setRecentFields] = useState(() => {
@@ -1856,6 +1949,7 @@ const MLModels = () => {
         setShowCreateModal={setShowCreateModal}
         handleCreateModel={handleCreateModel}
         mlUrl={mlUrl}
+        dataStorageUrl={'/' + import.meta.env.VITE_DATA_STORAGE_HOST}
       />
       {forceTarget && (
         <ForceFieldPickerModal
@@ -2051,13 +2145,27 @@ const MLModels = () => {
                 )}
               </div>
 
+              {/* Event type filter */}
+              <div className="flex gap-1">
+                {['', 'PERF_DATA', 'UE_MOBILITY', 'UE_COMM'].map(evt => (
+                  <button
+                    key={evt || 'all'}
+                    onClick={() => setFilterEvent(evt)}
+                    className={`px-2.5 py-1.5 text-xs font-semibold rounded-lg transition-colors ${
+                      filterEvent === evt
+                        ? evt === '' ? 'bg-gray-700 text-white' : `${EVENT_COLORS[evt]} ring-1 ring-current`
+                        : 'bg-white border border-gray-300 text-gray-600 hover:bg-gray-50'
+                    }`}
+                  >
+                    {evt || 'All'}
+                  </button>
+                ))}
+              </div>
+
               {/* Clear Filters */}
-              {(searchQuery || filterField) && (
+              {(searchQuery || filterField || filterEvent) && (
                 <button
-                  onClick={() => {
-                    setSearchQuery('');
-                    setFilterField('');
-                  }}
+                  onClick={() => { setSearchQuery(''); setFilterField(''); setFilterEvent(''); }}
                   className="px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
                 >
                   Clear Filters
@@ -2098,21 +2206,18 @@ const MLModels = () => {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {models
                 .filter(model => {
-                  // Filter by field
                   if (filterField === 'anomaly') {
-                    // Only show anomaly models
                     if (model.modelType !== 'anomaly') return false;
                   } else if (filterField) {
-                    // Only show forecast models when a specific field is selected
                     if (model.modelType === 'anomaly') return false;
                   }
-
-                  // Filter by search query
+                  if (filterEvent && model.event_type !== filterEvent) return false;
                   if (!searchQuery) return true;
-                  const query = searchQuery.toLowerCase();
+                  const q = searchQuery.toLowerCase();
                   return (
-                    model.name?.toLowerCase().includes(query) ||
-                    model.id?.toLowerCase().includes(query)
+                    model.name?.toLowerCase().includes(q) ||
+                    model.id?.toLowerCase().includes(q) ||
+                    model.event_type?.toLowerCase().includes(q)
                   );
                 })
                 .map((model) => (
@@ -2132,26 +2237,27 @@ const MLModels = () => {
                   />
                 ))}
             </div>
-            <div className="bg-gray-50 rounded-lg border border-gray-200 p-4 text-center">
-              <p className="text-sm text-gray-600">
-                Total Models: <span className="font-semibold text-gray-900">{models.filter(m => {
-                  // Filter by field
-                  if (filterField === 'anomaly') {
-                    // Only show anomaly models
-                    if (m.modelType !== 'anomaly') return false;
-                  } else if (filterField) {
-                    // Only show forecast models when a specific field is selected
-                    if (m.modelType === 'anomaly') return false;
-                  }
-
-                  // Filter by search query
-                  if (!searchQuery) return true;
-                  const query = searchQuery.toLowerCase();
-                  return m.name?.toLowerCase().includes(query) || m.id?.toLowerCase().includes(query);
-                }).length}</span>
-                {filterField && <span className="ml-2 text-gray-400">filtered by <span className="font-mono">{filterField}</span></span>}
-                {searchQuery && <span className="ml-2 text-gray-400">matching <span className="font-mono">"{searchQuery}"</span></span>}
-              </p>
+            <div className="bg-gray-50 rounded-lg border border-gray-200 p-3 flex flex-wrap items-center justify-between gap-3">
+              <div className="flex items-center gap-4 text-sm text-gray-600">
+                <span>Total: <span className="font-semibold text-gray-900">{models.length}</span></span>
+                <span>Trained: <span className="font-semibold text-green-700">{models.filter(m => m.latest_version != null).length}</span></span>
+                <span>Anomaly: <span className="font-semibold text-orange-700">{models.filter(m => m.modelType === 'anomaly').length}</span></span>
+              </div>
+              <div className="flex items-center gap-2 flex-wrap text-xs">
+                {['PERF_DATA','UE_MOBILITY','UE_COMM'].map(evt => {
+                  const count = models.filter(m => m.event_type === evt).length;
+                  return count > 0 ? (
+                    <span key={evt} className={`px-2 py-0.5 rounded font-medium ${EVENT_COLORS[evt]}`}>
+                      {evt}: {count}
+                    </span>
+                  ) : null;
+                })}
+                {(filterField || filterEvent || searchQuery) && (
+                  <span className="text-gray-400 ml-1">
+                    showing filtered results
+                  </span>
+                )}
+              </div>
             </div>
           </>
         )}

--- a/src/pages/MLModels.jsx
+++ b/src/pages/MLModels.jsx
@@ -116,7 +116,7 @@ const PolicyStatusBadge = ({ modelName, policyUrl }) => {
       {/* Modal for showing policy details */}
       {showModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
-          <div className="bg-white rounded-lg shadow-xl max-w-lg w-full p-6 max-h-[80vh] overflow-y-auto">
+          <div className="bg-white rounded-xl shadow-xl max-w-lg w-full p-6 max-h-[80vh] overflow-y-auto">
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-lg font-semibold text-gray-900">Policy Details</h3>
               <button
@@ -257,12 +257,12 @@ const ModelCard = memo(({ model, onShowDetails, onTrain, onSetDefault, onDelete,
               </span>
             )}
             {model.architecture && (
-              <span className="px-2 py-0.5 text-xs font-semibold bg-purple-100 text-purple-800 rounded uppercase tracking-wide">
+              <span className="px-2 py-0.5 text-xs font-semibold bg-gray-100 text-gray-600 rounded uppercase tracking-wide">
                 {model.architecture}
               </span>
             )}
             {model.modelType === 'anomaly' && (
-              <span className="px-2 py-0.5 text-xs font-bold bg-orange-200 text-orange-900 rounded uppercase tracking-wide">
+              <span className="px-2 py-0.5 text-xs font-bold bg-gray-200 text-gray-600 rounded uppercase tracking-wide">
                 anomaly
               </span>
             )}
@@ -293,7 +293,7 @@ const ModelCard = memo(({ model, onShowDetails, onTrain, onSetDefault, onDelete,
             </button>
             <button
               onClick={() => onTrain(model)}
-              className="flex-1 px-3 py-1.5 rounded-lg text-xs font-medium bg-green-600 text-white hover:bg-green-700 transition-colors flex items-center justify-center gap-1.5"
+              className="flex-1 px-3 py-1.5 rounded-lg text-xs font-medium bg-blue-600 text-white hover:bg-blue-700 transition-colors flex items-center justify-center gap-1.5"
             >
               {isTraining
                 ? <><div className="animate-spin rounded-full h-3 w-3 border-b-2 border-white shrink-0"></div>Training</>
@@ -527,9 +527,9 @@ const FieldCheckboxes = ({ fieldKey, label, fields, loadingFields, selected, onT
 };
 
 const EVENT_COLORS = {
-  PERF_DATA:   'bg-blue-100 text-blue-800',
-  UE_MOBILITY: 'bg-purple-100 text-purple-800',
-  UE_COMM:     'bg-green-100 text-green-800',
+  PERF_DATA:   'bg-blue-50 text-blue-700',
+  UE_MOBILITY: 'bg-gray-100 text-gray-600',
+  UE_COMM:     'bg-gray-100 text-gray-600',
 };
 
 const intersectSets = (sets) => {
@@ -638,11 +638,11 @@ const CreateModelModal = memo(({ showCreateModal, setShowCreateModal, handleCrea
 
 
   return (
-    <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-md w-full flex flex-col max-h-[90vh]">
-        <div className="bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between rounded-t-lg flex-shrink-0">
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-xl max-w-md w-full flex flex-col max-h-[90vh]">
+        <div className="bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between rounded-t-xl rounded-t-lg flex-shrink-0">
           <div>
-            <h3 className="text-xl font-bold text-gray-900">Create new Instance</h3>
+            <h3 className="text-lg font-semibold text-gray-900">Create new Instance</h3>
             <p className="text-sm text-gray-600 mt-1">Instantiate a model</p>
           </div>
           <button onClick={() => setShowCreateModal(false)} className="text-gray-400 hover:text-gray-600 transition-colors">
@@ -844,8 +844,8 @@ const ForceFieldPickerModal = ({ model, fields, onConfirm, onCancel }) => {
   const [selected, setSelected] = useState(fields[0] ?? '');
   if (!model) return null;
   return (
-    <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-sm w-full p-6 space-y-4">
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-xl max-w-sm w-full p-6 space-y-4">
         <h3 className="text-lg font-bold text-gray-900">Set Best Model</h3>
         <p className="text-sm text-gray-600">
           <span className="font-medium">{model.name}</span> has multiple output fields. Choose which field to set this model as best for:
@@ -958,11 +958,11 @@ const AllJobsModal = ({ showModal, setShowModal, mlUrl, onJobsUpdate }) => {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] flex flex-col">
-        <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between flex-shrink-0">
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-xl max-w-4xl w-full max-h-[90vh] flex flex-col">
+        <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between rounded-t-xl flex-shrink-0">
           <div>
-            <h3 className="text-xl font-bold text-gray-900">Training Jobs</h3>
+            <h3 className="text-lg font-semibold text-gray-900">Training Jobs</h3>
             <p className="text-sm text-gray-600 mt-1">All training jobs across all models</p>
           </div>
           <div className="flex items-center gap-3">
@@ -1003,8 +1003,11 @@ const AllJobsModal = ({ showModal, setShowModal, mlUrl, onJobsUpdate }) => {
                 <tbody className="divide-y divide-gray-100">
                   {jobs.map((job) => (
                     <tr key={job.job_id} className="hover:bg-gray-50">
-                      <td className="px-4 py-2 font-mono text-xs text-gray-600" title={job.job_id}>
-                        {job.job_id?.slice(0, 8)}…
+                      <td className="px-4 py-2">
+                        <div className="flex items-center gap-1.5">
+                          <span className="font-mono text-xs text-gray-600" title={job.job_id}>{job.job_id?.slice(0,8)}…</span>
+                          <button onClick={() => copyToClipboard(job.job_id, job.job_id + "-jid")} className="p-1 rounded hover:bg-gray-100 transition-colors" title="Copy Job ID">{copiedId === job.job_id + "-jid" ? <svg className="w-3 h-3 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg> : <svg className="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>}</button>
+                        </div>
                       </td>
                       <td className="px-4 py-2">
                         <div className="flex items-center gap-2">
@@ -1012,11 +1015,11 @@ const AllJobsModal = ({ showModal, setShowModal, mlUrl, onJobsUpdate }) => {
                             {job.model_id?.slice(0, 8)}…
                           </span>
                           <button
-                            onClick={() => copyToClipboard(job.model_id, job.model_id)}
+                            onClick={() => copyToClipboard(job.model_id, job.job_id + "-mid")}
                             className="p-1 hover:bg-gray-200 rounded transition-colors"
                             title="Copy model ID"
                           >
-                            {copiedId === job.model_id ? (
+                            {copiedId === job.job_id + "-mid" ? (
                               <svg className="w-3.5 h-3.5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                               </svg>
@@ -1060,6 +1063,12 @@ const TrainingModal = ({ model, mlUrl, onClose, onStartTraining, isTraining }) =
   const [loadingJobs, setLoadingJobs] = useState(true);
   const [cancellingIds, setCancellingIds] = useState(new Set());
   const intervalRef = useRef(null);
+  const [copiedId, setCopiedId] = useState(null);
+  const copyId = (text, id) => {
+    const fb = () => { const el = document.createElement("textarea"); el.value = text; el.style.cssText = "position:fixed;opacity:0"; document.body.appendChild(el); el.select(); document.execCommand("copy"); document.body.removeChild(el); };
+    navigator.clipboard?.writeText(text).catch(fb) ?? fb();
+    setCopiedId(id); setTimeout(() => setCopiedId(null), 2000);
+  };
 
   const [resourceCpu, setResourceCpu] = useState('');
   const [resourceMemory, setResourceMemory] = useState('');
@@ -1155,12 +1164,12 @@ const TrainingModal = ({ model, mlUrl, onClose, onStartTraining, isTraining }) =
   };
 
   return (
-    <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] flex flex-col">
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-xl max-w-2xl w-full max-h-[90vh] flex flex-col">
         {/* Header */}
-        <div className="border-b border-gray-200 px-6 py-4 flex items-center justify-between flex-shrink-0">
+        <div className="border-b border-gray-200 px-6 py-4 flex items-center justify-between rounded-t-xl flex-shrink-0">
           <div>
-            <h3 className="text-xl font-bold text-gray-900">Train</h3>
+            <h3 className="text-lg font-semibold text-gray-900">Train</h3>
             <p className="text-sm text-gray-600 mt-1">{model.name}</p>
           </div>
           <button onClick={onClose} className="text-gray-400 hover:text-gray-600 transition-colors">
@@ -1277,8 +1286,11 @@ const TrainingModal = ({ model, mlUrl, onClose, onStartTraining, isTraining }) =
                       const isActive = job.status === 'running' || job.status === 'pending';
                       return (
                         <tr key={job.job_id} className="hover:bg-gray-50">
-                          <td className="px-4 py-2 font-mono text-xs text-gray-600" title={job.job_id}>
-                            {job.job_id?.slice(0, 8)}…
+                          <td className="px-4 py-2">
+                            <div className="flex items-center gap-1">
+                              <span className="font-mono text-xs text-gray-600" title={job.job_id}>{job.job_id?.slice(0,8)}…</span>
+                              <button onClick={() => copyId(job.job_id, "tm-" + job.job_id)} className="p-0.5 rounded hover:bg-gray-100 transition-colors">{copiedId === "tm-" + job.job_id ? <svg className="w-3 h-3 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7"/></svg> : <svg className="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>}</button>
+                            </div>
                           </td>
                           <td className="px-4 py-2">
                             <span className={statusBadge(job.status)}>{job.status}</span>
@@ -1323,6 +1335,12 @@ const ModelDetailsModal = memo(({ showModal, setShowModal, selectedModel, loadin
   const [importance, setImportance] = useState(null);
   const [loadingImportance, setLoadingImportance] = useState(false);
   const [triggeringImportance, setTriggeringImportance] = useState(false);
+  const [copiedId, setCopiedId] = useState(null);
+  const copyToClipboard = (text, id) => {
+    const fb = () => { const el = document.createElement("textarea"); el.value = text; el.style.cssText = "position:fixed;opacity:0"; document.body.appendChild(el); el.select(); document.execCommand("copy"); document.body.removeChild(el); };
+    navigator.clipboard?.writeText(text).catch(fb) ?? fb();
+    setCopiedId(id); setTimeout(() => setCopiedId(null), 2000);
+  };
 
   const isAnomaly = selectedModel?.modelType === 'anomaly';
   const config = modelDetails?.config || {};
@@ -1359,8 +1377,8 @@ const ModelDetailsModal = memo(({ showModal, setShowModal, selectedModel, loadin
 
   if (loadingDetails) {
     return (
-      <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-        <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full">
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+        <div className="bg-white rounded-xl shadow-xl max-w-2xl w-full">
           <div className="p-12 flex items-center justify-center">
             <div className="text-center">
               <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
@@ -1374,8 +1392,8 @@ const ModelDetailsModal = memo(({ showModal, setShowModal, selectedModel, loadin
 
   if (!modelDetails) {
     return (
-      <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-        <div className="bg-white rounded-lg shadow-xl max-w-md w-full">
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+        <div className="bg-white rounded-xl shadow-xl max-w-md w-full">
           <div className="p-12 text-center">
             <p className="text-gray-500">No model details available</p>
             <button onClick={() => setShowModal(false)} className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">Close</button>
@@ -1386,11 +1404,11 @@ const ModelDetailsModal = memo(({ showModal, setShowModal, selectedModel, loadin
   }
 
   return (
-    <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] flex flex-col">
-        <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between flex-shrink-0">
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-xl max-w-2xl w-full max-h-[90vh] flex flex-col">
+        <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between rounded-t-xl flex-shrink-0">
           <div>
-            <h3 className="text-xl font-bold text-gray-900">Model Details</h3>
+            <h3 className="text-lg font-semibold text-gray-900">Model Details</h3>
             <p className="text-sm text-gray-600 mt-1">{modelDetails.name}</p>
           </div>
           <button onClick={() => setShowModal(false)} className="text-gray-400 hover:text-gray-600 transition-colors">
@@ -1512,7 +1530,10 @@ const ModelDetailsModal = memo(({ showModal, setShowModal, selectedModel, loadin
                 {modelDetails.mlflow_run_id && (
                   <div className="flex justify-between items-center">
                     <span className="text-gray-600">MLflow Run ID:</span>
-                    <span className="font-mono text-xs text-gray-900">{modelDetails.mlflow_run_id}</span>
+                    <div className="flex items-center gap-1.5">
+                      <span className="font-mono text-xs text-gray-900" title={modelDetails.mlflow_run_id}>{modelDetails.mlflow_run_id.slice(0,12)}…</span>
+                      <button onClick={() => copyToClipboard(modelDetails.mlflow_run_id, "mlflow-run-id")} className="p-1 rounded hover:bg-gray-100 transition-colors" title="Copy MLflow Run ID">{copiedId === "mlflow-run-id" ? <svg className="w-3.5 h-3.5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg> : <svg className="w-3.5 h-3.5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>}</button>
+                    </div>
                   </div>
                 )}
               </div>
@@ -1988,17 +2009,17 @@ const MLModels = () => {
 
       <div className="space-y-6">
         {/* Header */}
-        <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+        <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
           {/* Header */}
           <div className="flex items-center justify-between flex-wrap gap-3">
             <div className="flex-1">
-              <h2 className="text-2xl font-bold text-gray-900">ML Registry</h2>
+              <h2 className="text-xl font-semibold text-gray-900">ML Registry</h2>
               <p className="text-sm text-gray-600 mt-1">Browse and manage ML models</p>
             </div>
             <div className="flex items-center gap-3 flex-wrap">
               <button
                 onClick={() => setShowAllJobsModal(true)}
-                className="px-4 py-2 text-sm font-medium text-white bg-orange-500 hover:bg-orange-600 rounded-lg transition-colors flex items-center gap-2"
+                className="px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 bg-white hover:bg-gray-50 rounded-lg transition-colors flex items-center gap-2"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
@@ -2007,25 +2028,13 @@ const MLModels = () => {
               </button>
               <button
                 onClick={() => setShowCreateModal(true)}
-                className="px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-lg transition-colors flex items-center gap-2"
+                className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors flex items-center gap-2"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
                 </svg>
                 New Instance
               </button>
-
-              <a
-                href={mlflowUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 rounded-lg transition-all shadow-sm hover:shadow-md flex items-center gap-2"
-              >
-                <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M12 2L2 7v10c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-10-5zm0 2.18l8 4v8.82c0 4.52-3.13 8.74-8 9.82-4.87-1.08-8-5.3-8-9.82V8.18l8-4zM11 7v2h2V7h-2zm0 4v6h2v-6h-2z" />
-                </svg>
-                Open in MLflow
-              </a>
 
               {lastUpdated && (
                 <span className="text-xs text-gray-500">Updated: {lastUpdated.toLocaleTimeString()}</span>

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -38,13 +38,13 @@ export default function NotFound() {
         <rect x="34" y="145" width="62" height="8" rx="2" fill="#f97316" />
       </svg>
 
-      <h1 className="text-4xl font-bold text-gray-800 mt-6 mb-2">Page Not Found</h1>
-      <p className="text-gray-500 mb-8 max-w-sm">
+      <h1 className="text-3xl font-semibold text-gray-800 mt-6 mb-2">Page Not Found</h1>
+      <p className="text-gray-500 mb-8 max-w-sm text-sm">
         The page you are looking for doesn't exist or has been moved
       </p>
       <Link
         to="/"
-        className="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors"
+        className="px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg text-sm transition-colors"
       >
         Go to Dashboard
       </Link>

--- a/src/pages/Performance.jsx
+++ b/src/pages/Performance.jsx
@@ -55,8 +55,12 @@ const StateBadge = ({ state }) => {
 const Performance = () => {
   const mlUrl = '/' + import.meta.env.VITE_ML_HOST;
 
+  const PERF_KEY = 'aion-performance-state';
+
   const [fields, setFields] = useState([]);
-  const [activeField, setActiveField] = useState('');
+  const [activeField, setActiveField] = useState(() => {
+    try { return sessionStorage.getItem(PERF_KEY) || ''; } catch { return ''; }
+  });
 
   // Per-field data
   const [status, setStatus] = useState(null);
@@ -458,7 +462,7 @@ const Performance = () => {
 
   if (!fields.length) {
     return (
-      <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm text-center text-gray-500">
+      <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm text-center text-gray-500">
         No fields available from the ML service.
       </div>
     );
@@ -479,7 +483,7 @@ const Performance = () => {
             <SearchableDropdown
               options={fields}
               value={activeField}
-              onChange={setActiveField}
+              onChange={(v) => { setActiveField(v); try { sessionStorage.setItem(PERF_KEY, v); } catch {} }}
               placeholder="Search fields..."
               recentSearchKey="performance-fields"
               formatOption={(f) => f}
@@ -574,7 +578,7 @@ const Performance = () => {
       ) : (
         <>
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2 bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+          <div className="lg:col-span-2 bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
             <div className="mb-4 space-y-2">
               <div className="flex items-center justify-between">
                 <h3 className="text-base font-semibold text-gray-900">Score History</h3>
@@ -741,7 +745,7 @@ const Performance = () => {
 
         {/* Feature Importance panel - only when a best model is elected */}
         {bestModel && (
-          <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+          <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center gap-2">
                 <h3 className="text-base font-semibold text-gray-900">Feature Importance</h3>

--- a/src/pages/Policy.jsx
+++ b/src/pages/Policy.jsx
@@ -631,14 +631,14 @@ const Policy = () => {
       )}
 
       {/* Header */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+      <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center space-x-4 min-w-0">
             <div className="p-3 bg-blue-100 rounded-lg shrink-0">
               <FaShieldAlt className="text-2xl text-blue-600" />
             </div>
             <div className="min-w-0">
-              <h2 className="text-2xl font-bold text-gray-900">Policy Configuration</h2>
+              <h2 className="text-xl font-semibold text-gray-900">Policy Configuration</h2>
               <p className="text-sm text-gray-600">Configure transformer pipelines and field permissions</p>
             </div>
           </div>
@@ -776,7 +776,7 @@ const Policy = () => {
               <div className="flex items-center space-x-3 text-sm text-gray-600">
                 <span>{Object.keys(pipelines).length} pipeline{Object.keys(pipelines).length !== 1 ? 's' : ''} total</span>
                 {isNewPipeline && (
-                  <span className="text-xs text-orange-600 bg-orange-50 px-2 py-1 rounded">
+                  <span className="text-xs text-amber-700 bg-amber-50 px-2 py-1 rounded">
                     New - Unsaved
                   </span>
                 )}
@@ -858,7 +858,7 @@ const Policy = () => {
           />
 
           {/* Field Transformations */}
-          <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+          <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
             <div className="flex items-center justify-between mb-4">
               <div>
                 <h3 className="text-lg font-semibold text-gray-900">Field Transformations</h3>
@@ -888,8 +888,8 @@ const Policy = () => {
                       <div className="flex-1 min-w-0 mr-4">
                         <div className="flex items-center space-x-3 mb-2">
                           {step.type === 'hashing' ? (
-                            <span className="flex items-center space-x-1.5 px-2.5 py-1 bg-purple-100 text-purple-800 text-xs font-semibold rounded-full">
-                              <span className="w-2 h-2 bg-purple-500 rounded-full"></span>
+                            <span className="flex items-center space-x-1.5 px-2.5 py-1 bg-purple-100 text-blue-800 text-xs font-semibold rounded-full">
+                              <span className="w-2 h-2 bg-blue-500 rounded-full"></span>
                               <span>Hashing</span>
                             </span>
                           ) : step.type === 'redaction' ? (
@@ -1023,13 +1023,13 @@ const Policy = () => {
       {/* Transformation Detail Modal */}
       {showStepDetailModal && detailStep && (
         <div className="fixed inset-0 bg-gray-900/20 backdrop-blur-sm flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
             {/* Header */}
             <div className="flex items-center justify-between p-6 border-b border-gray-200">
               <div className="flex items-center space-x-3">
                 {detailStep.type === 'hashing' ? (
-                  <span className="flex items-center space-x-2 px-3 py-1.5 bg-purple-100 text-purple-800 text-sm font-semibold rounded-full">
-                    <span className="w-2.5 h-2.5 bg-purple-500 rounded-full"></span>
+                  <span className="flex items-center space-x-2 px-3 py-1.5 bg-purple-100 text-blue-800 text-sm font-semibold rounded-full">
+                    <span className="w-2.5 h-2.5 bg-blue-500 rounded-full"></span>
                     <span>Hashing Transformation</span>
                   </span>
                 ) : detailStep.type === 'redaction' ? (
@@ -1104,7 +1104,7 @@ const Policy = () => {
       {/* New Pipeline Modal */}
       {showNewPipelineModal && (
         <div className="fixed inset-0 bg-gray-900/20 backdrop-blur-sm flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg shadow-xl w-full max-w-3xl max-h-[90vh] overflow-hidden flex flex-col">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-3xl max-h-[90vh] overflow-hidden flex flex-col">
             {/* Header */}
             <div className="flex items-center justify-between p-6 border-b border-gray-200">
               <div className="flex items-center space-x-4">
@@ -1217,9 +1217,9 @@ const Policy = () => {
                 if (!sourceComp?.mlModelMeta) return null;
                 const meta = sourceComp.mlModelMeta;
                 return (
-                  <div className="mb-4 bg-purple-50 border border-purple-200 rounded-lg p-4">
+                  <div className="mb-4 bg-blue-50 border border-blue-200 rounded-lg p-4">
                     <div className="flex items-center justify-between mb-2">
-                      <h4 className="text-sm font-medium text-purple-900">
+                      <h4 className="text-sm font-medium text-blue-900">
                         🤖 ML Model: {sourceComp.name}
                       </h4>
                       {meta.inputFields?.length > 0 && (
@@ -1227,13 +1227,13 @@ const Policy = () => {
                           onClick={() => {
                             setHighlightedFields(new Set(meta.inputFields));
                           }}
-                          className="text-sm px-3 py-1 bg-purple-200 text-purple-900 rounded hover:bg-purple-300 transition-colors"
+                          className="text-sm px-3 py-1 bg-purple-200 text-blue-900 rounded hover:bg-purple-300 transition-colors"
                         >
                           Highlight Training Fields
                         </button>
                       )}
                     </div>
-                    <div className="grid grid-cols-2 gap-2 text-xs text-purple-800">
+                    <div className="grid grid-cols-2 gap-2 text-xs text-blue-800">
                       {meta.architecture && <div><span className="font-medium">Architecture:</span> {meta.architecture}</div>}
                       {meta.windowDuration && <div><span className="font-medium">Window:</span> {meta.windowDuration}s</div>}
                       <div className="col-span-2">
@@ -1255,9 +1255,9 @@ const Policy = () => {
                 if (!sinkComp?.mlModelMeta) return null;
                 const meta = sinkComp.mlModelMeta;
                 return (
-                  <div className="mb-4 bg-purple-50 border border-purple-200 rounded-lg p-4">
+                  <div className="mb-4 bg-blue-50 border border-blue-200 rounded-lg p-4">
                     <div className="flex items-center justify-between mb-2">
-                      <h4 className="text-sm font-medium text-purple-900">
+                      <h4 className="text-sm font-medium text-blue-900">
                         🤖 ML Model: {sinkComp.name}
                       </h4>
                       {meta.inputFields?.length > 0 && (
@@ -1265,13 +1265,13 @@ const Policy = () => {
                           onClick={() => {
                             setHighlightedFields(new Set(meta.inputFields));
                           }}
-                          className="text-sm px-3 py-1 bg-purple-200 text-purple-900 rounded hover:bg-purple-300 transition-colors"
+                          className="text-sm px-3 py-1 bg-purple-200 text-blue-900 rounded hover:bg-purple-300 transition-colors"
                         >
                           Highlight Training Fields
                         </button>
                       )}
                     </div>
-                    <div className="grid grid-cols-2 gap-2 text-xs text-purple-800">
+                    <div className="grid grid-cols-2 gap-2 text-xs text-blue-800">
                       {meta.architecture && <div><span className="font-medium">Architecture:</span> {meta.architecture}</div>}
                       {meta.windowDuration && <div><span className="font-medium">Window:</span> {meta.windowDuration}s</div>}
                       <div className="col-span-2">
@@ -1401,8 +1401,8 @@ const Policy = () => {
                     );
                   }
                   return (
-                    <div className="mb-6 bg-purple-50 border border-purple-200 rounded-lg p-4">
-                      <label className="block text-sm font-medium text-purple-900 mb-2">
+                    <div className="mb-6 bg-blue-50 border border-blue-200 rounded-lg p-4">
+                      <label className="block text-sm font-medium text-blue-900 mb-2">
                         Select ML Models (Sink)
                       </label>
                       <p className="text-xs text-purple-700 mb-3">
@@ -1438,7 +1438,7 @@ const Policy = () => {
                               />
                               <div className="flex items-start justify-between">
                                 <div className="flex-1">
-                                  <div className="font-medium text-purple-900 text-sm">{model.name}</div>
+                                  <div className="font-medium text-blue-900 text-sm">{model.name}</div>
                                   {meta.architecture && (
                                     <div className="text-xs text-purple-600">{meta.architecture}</div>
                                   )}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useAccessibility } from '../contexts/AccessibilityContext';
+import { FaSun, FaMoon, FaDesktop } from 'react-icons/fa';
 
 const FONT_SIZE_OPTIONS = [
   { value: 'small',  label: 'S' },
@@ -9,21 +10,15 @@ const FONT_SIZE_OPTIONS = [
 ];
 
 const CVD_OPTIONS = [
-  {
-    value: 'none',
-    label: 'None',
-    description: 'Standard color palette.',
-  },
-  {
-    value: 'rg',
-    label: 'Red-Green',
-    description: 'For deuteranopia & protanopia.',
-  },
-  {
-    value: 'tritan',
-    label: 'Tritanopia',
-    description: 'For blue-yellow deficiency.',
-  },
+  { value: 'none',   label: 'None',        description: 'Standard color palette.' },
+  { value: 'rg',     label: 'Red-Green',   description: 'For deuteranopia & protanopia.' },
+  { value: 'tritan', label: 'Tritanopia',  description: 'For blue-yellow deficiency.' },
+];
+
+const THEME_OPTIONS = [
+  { value: 'light',  label: 'Light',  Icon: FaSun },
+  { value: 'dark',   label: 'Dark',   Icon: FaMoon },
+  { value: 'system', label: 'System', Icon: FaDesktop },
 ];
 
 const Toggle = ({ id, checked, onChange, label, description }) => (
@@ -50,30 +45,75 @@ const Toggle = ({ id, checked, onChange, label, description }) => (
   </div>
 );
 
+const SectionCard = ({ title, description, children }) => (
+  <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
+    <h2 className="text-sm font-semibold text-gray-900 mb-0.5">{title}</h2>
+    {description && <p className="text-xs text-gray-500 mb-4">{description}</p>}
+    {children}
+  </div>
+);
+
 const Settings = () => {
   const { preferences, setPreference } = useAccessibility();
 
   return (
-    <div className="max-w-4xl mx-auto">
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div className="max-w-4xl mx-auto space-y-4">
 
-        <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
-          <h2 className="text-base font-semibold text-gray-900 mb-1">Display</h2>
-          <p className="text-sm text-gray-500 mb-2">Adjust visual contrast to improve readability.</p>
+      {/* Theme */}
+      <SectionCard
+        title="Theme"
+        description="Choose light, dark, or follow your system preference."
+      >
+        <div className="grid grid-cols-3 gap-2" role="group" aria-label="Color theme">
+          {THEME_OPTIONS.map(({ value, label, Icon }) => {
+            const isActive = preferences.theme === value;
+            return (
+              <button
+                key={value}
+                onClick={() => setPreference('theme', value)}
+                aria-pressed={isActive}
+                className={`flex flex-col items-center gap-2 px-3 py-4 rounded-lg border-2 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 ${
+                  isActive
+                    ? 'border-blue-600 bg-blue-50 text-blue-700'
+                    : 'border-gray-200 text-gray-500 hover:border-gray-300 hover:text-gray-700'
+                }`}
+              >
+                <Icon className="text-lg" />
+                <span className="text-xs font-semibold">{label}</span>
+              </button>
+            );
+          })}
+        </div>
+        {preferences.theme === 'system' && (
+          <p className="text-xs text-gray-400 mt-3 text-center">
+            Follows your OS preference automatically.
+          </p>
+        )}
+      </SectionCard>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+
+        {/* Display */}
+        <SectionCard
+          title="Display"
+          description="Adjust visual contrast to improve readability."
+        >
           <div className="divide-y divide-gray-100">
             <Toggle
               id="high-contrast"
               checked={preferences.highContrast}
               onChange={(val) => setPreference('highContrast', val)}
               label="High Contrast"
-              description="Forces stark black and white backgrounds with strongly defined borders."
+              description="Forces stark black/white backgrounds with strong borders."
             />
           </div>
-        </div>
+        </SectionCard>
 
-        <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
-          <h2 className="text-base font-semibold text-gray-900 mb-1">Text Size</h2>
-          <p className="text-sm text-gray-500 mb-4">Adjust the base font size across the dashboard.</p>
+        {/* Text Size */}
+        <SectionCard
+          title="Text Size"
+          description="Adjust the base font size across the dashboard."
+        >
           <div className="flex gap-2" role="group" aria-label="Text size">
             {FONT_SIZE_OPTIONS.map(opt => (
               <button
@@ -90,50 +130,35 @@ const Settings = () => {
               </button>
             ))}
           </div>
-        </div>
-
-        <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm md:col-span-2">
-          <h2 className="text-base font-semibold text-gray-900 mb-1">Color Vision</h2>
-          <p className="text-sm text-gray-500 mb-4">
-            Select a palette correction for your type of color vision deficiency.
-          </p>
-          <div role="radiogroup" aria-label="Color vision mode" className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-            {CVD_OPTIONS.map(opt => (
-              <button
-                key={opt.value}
-                role="radio"
-                aria-checked={preferences.colorVision === opt.value}
-                onClick={() => setPreference('colorVision', opt.value)}
-                className={`text-left px-4 py-3 rounded-lg border-2 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 ${
-                  preferences.colorVision === opt.value
-                    ? 'border-blue-600 bg-blue-50'
-                    : 'border-gray-200 hover:border-gray-300'
-                }`}
-              >
-                <span className="block text-sm font-medium text-gray-900">{opt.label}</span>
-                <span className="block text-xs text-gray-500 mt-0.5">{opt.description}</span>
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Motion - commented out for now
-        <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm md:col-span-2">
-          <h2 className="text-base font-semibold text-gray-900 mb-1">Motion</h2>
-          <p className="text-sm text-gray-500 mb-2">Disable transitions and animations that may cause discomfort.</p>
-          <div className="divide-y divide-gray-100">
-            <Toggle
-              id="reduced-motion"
-              checked={preferences.reducedMotion}
-              onChange={(val) => setPreference('reducedMotion', val)}
-              label="Reduce Motion"
-              description="Disables all CSS transitions and animations across the dashboard."
-            />
-          </div>
-        </div>
-        */}
+        </SectionCard>
 
       </div>
+
+      {/* Color Vision */}
+      <SectionCard
+        title="Color Vision"
+        description="Select a palette correction for your type of color vision deficiency."
+      >
+        <div role="radiogroup" aria-label="Color vision mode" className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+          {CVD_OPTIONS.map(opt => (
+            <button
+              key={opt.value}
+              role="radio"
+              aria-checked={preferences.colorVision === opt.value}
+              onClick={() => setPreference('colorVision', opt.value)}
+              className={`text-left px-4 py-3 rounded-lg border-2 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 ${
+                preferences.colorVision === opt.value
+                  ? 'border-blue-600 bg-blue-50'
+                  : 'border-gray-200 hover:border-gray-300'
+              }`}
+            >
+              <span className="block text-sm font-medium text-gray-900">{opt.label}</span>
+              <span className="block text-xs text-gray-500 mt-0.5">{opt.description}</span>
+            </button>
+          ))}
+        </div>
+      </SectionCard>
+
     </div>
   );
 };


### PR DESCRIPTION
## Summary
Full visual overhaul of all pages. Enhance design system, dark mode, and several UX fixes.

## What changed
**Design system**
   - New font: Outfit (UI) + JetBrains Mono (data)
   - CSS variable token system for light and dark themes
   - Dark mode toggled via `.dark` class 

**Theme**
- `Settings` page now has a Theme section: Light / Dark / System (default: system preference)
- System mode reacts to OS preference changes in real time

**Layout**
- Sidebar redesigned with CSS variables, collapsible, MLflow external link added

**UX fixes**
- Copy bug fixed: training job table was showing checkmark on all rows with same model ID — now uses unique key per row
- Copy buttons added: NEF URL, Notif ID (Ingestion), MLflow Run ID, Job ID (training modals)
- Page state persists across navigation: Analytics form and Performance field selection survive route changes via `sessionStorage`

**Color cleanup**
- Removed decorative orange/purple badges — architecture, anomaly, event type badges now neutral gray
- Action buttons unified: primary actions blue, destructive red, secondary ghost

<img width="1886" height="1007" alt="screenshot_2026-05-02_22-20-05" src="https://github.com/user-attachments/assets/fd806722-8b9c-45c6-9336-bed54a8af843" />
<img width="1885" height="1005" alt="screenshot_2026-05-02_22-19-43" src="https://github.com/user-attachments/assets/6eec9594-33b0-485c-8010-0daa641375f1" />
<img width="1893" height="998" alt="screenshot_2026-05-02_22-19-57" src="https://github.com/user-attachments/assets/095f8470-15d7-46a6-bc2c-096b8f36848a" />
